### PR TITLE
Fix very nonobvious `check` behavior for `OrderableSlsVersion` and `NonOrderableSlsVersion`

### DIFF
--- a/sls-versions/src/main/java/com/palantir/sls/versions/CompactVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/CompactVersion.java
@@ -112,7 +112,7 @@ public final class CompactVersion implements Comparable<CompactVersion> {
         throw new SafeIllegalArgumentException("Unknown SlsVersionType", SafeArg.of("slsVersionType", type));
     }
 
-    private static long encode20b(int value, @CompileTimeConstant String component) {
+    private static long encode20b(int value, @CompileTimeConstant final String component) {
         Preconditions.checkArgument(value >= 0 && value < 1_048_576,
                 "version component must be positive and not exceed 20 bits of value",
                 SafeArg.of(component, value));
@@ -151,8 +151,8 @@ public final class CompactVersion implements Comparable<CompactVersion> {
                 firstSeq = OptionalInt.of(rcNumber);
                 secondSeq = OptionalInt.of(distanceFromVersion);
                 break;
-            default:
-                // nothing
+            case RELEASE:
+            case NON_ORDERABLE:
                 break;
         }
         return new OrderableSlsVersion.Builder()

--- a/sls-versions/src/main/java/com/palantir/sls/versions/CompactVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/CompactVersion.java
@@ -112,7 +112,7 @@ public final class CompactVersion implements Comparable<CompactVersion> {
         throw new SafeIllegalArgumentException("Unknown SlsVersionType", SafeArg.of("slsVersionType", type));
     }
 
-    private static long encode20b(int value, @CompileTimeConstant final String component) {
+    private static long encode20b(int value, @CompileTimeConstant String component) {
         Preconditions.checkArgument(value >= 0 && value < 1_048_576,
                 "version component must be positive and not exceed 20 bits of value",
                 SafeArg.of(component, value));

--- a/sls-versions/src/main/java/com/palantir/sls/versions/NonOrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/NonOrderableSlsVersion.java
@@ -55,6 +55,14 @@ public abstract class NonOrderableSlsVersion extends SlsVersion {
                 .build());
     }
 
+    /**
+     * Returns true iff the given coordinate has a version which can be parsed into a valid SLS version, but not an
+     * orderable one.
+     */
+    public static boolean check(String coordinate) {
+        return safeValueOf(coordinate).isPresent() && !OrderableSlsVersion.check(coordinate);
+    }
+
     @JsonValue
     @Override
     public final String toString() {

--- a/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
@@ -90,6 +90,13 @@ public abstract class OrderableSlsVersion extends SlsVersion {
         return null;
     }
 
+    /**
+     * Returns true iff the given coordinaten has a version which can be parsed into a valid orderable SLS version.
+     */
+    public static boolean check(String coordinate) {
+        return safeValueOf(coordinate).isPresent();
+    }
+
     @JsonValue
     @Override
     public final String toString() {

--- a/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
@@ -91,7 +91,7 @@ public abstract class OrderableSlsVersion extends SlsVersion {
     }
 
     /**
-     * Returns true iff the given coordinaten has a version which can be parsed into a valid orderable SLS version.
+     * Returns true iff the given coordinate has a version which can be parsed into a valid orderable SLS version.
      */
     public static boolean check(String coordinate) {
         return safeValueOf(coordinate).isPresent();

--- a/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersion.java
@@ -17,6 +17,8 @@
 package com.palantir.sls.versions;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Optional;
 import java.util.OptionalInt;
 import org.immutables.value.Value;
@@ -33,7 +35,8 @@ public abstract class SlsVersion {
         if (optionalNonOrderableVersion.isPresent()) {
             return optionalNonOrderableVersion.get();
         }
-        throw new IllegalArgumentException("Value is neither an orderable nor a non-orderable version: " + value);
+        throw new SafeIllegalArgumentException("Value is neither an orderable nor a non-orderable version",
+                UnsafeArg.of("value", value));
     }
 
     /**
@@ -43,7 +46,7 @@ public abstract class SlsVersion {
         try {
             valueOf(coordinate);
             return true;
-        } catch (IllegalArgumentException e) {
+        } catch (SafeIllegalArgumentException e) {
             return false;
         }
     }

--- a/sls-versions/src/test/java/com/palantir/sls/versions/NonOrderableVersionTests.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/NonOrderableVersionTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -49,7 +50,7 @@ public class NonOrderableVersionTests {
     public void testCannotCreateInvalidVersions() {
         for (String v : ILLEGAL_VERSIONS) {
             assertThatThrownBy(() -> NonOrderableSlsVersion.valueOf(v))
-                    .isInstanceOf(IllegalArgumentException.class);
+                    .isInstanceOf(SafeIllegalArgumentException.class);
         }
     }
 
@@ -65,7 +66,7 @@ public class NonOrderableVersionTests {
     @Test
     public void testIncorrectPatchVersionParsing() {
         assertThatThrownBy(() -> NonOrderableSlsVersion.valueOf("1.2.foo"))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(SafeIllegalArgumentException.class);
     }
 
     @Test

--- a/sls-versions/src/test/java/com/palantir/sls/versions/NonOrderableVersionTests.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/NonOrderableVersionTests.java
@@ -85,4 +85,19 @@ public class NonOrderableVersionTests {
         NonOrderableSlsVersion deserialized = mapper.readValue(serialized, NonOrderableSlsVersion.class);
         assertThat(deserialized).isEqualTo(version);
     }
+
+    @Test
+    public void testCheckWithOrderableVersion() {
+        assertThat(NonOrderableSlsVersion.check("1.0.0")).isFalse();
+    }
+
+    @Test
+    public void testCheckWithNonOrderableVersion() {
+        assertThat(NonOrderableSlsVersion.check("1.0.0-foo")).isTrue();
+    }
+
+    @Test
+    public void testCheckWithGarbage() {
+        assertThat(NonOrderableSlsVersion.check("foo")).isFalse();
+    }
 }

--- a/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
@@ -201,11 +201,11 @@ public class OrderableSlsVersionTests {
         assertThat(OrderableSlsVersion.check("1.0.0-foo")).isFalse();
     }
 
-
     @Test
     public void testCheckWithGarbage() {
         assertThat(OrderableSlsVersion.check("foo")).isFalse();
     }
+
     @Test
     public void testEqualVersions() {
         assertVersionsEqual("1.0.0", "1.0.0");

--- a/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -73,7 +74,7 @@ public class OrderableSlsVersionTests {
     public void testCannotCreateInvalidVersions() {
         for (String v : ILLEGAL_VERSIONS) {
             assertThatThrownBy(() -> OrderableSlsVersion.valueOf(v))
-                    .isInstanceOf(IllegalArgumentException.class);
+                    .isInstanceOf(SafeIllegalArgumentException.class);
         }
     }
 
@@ -190,6 +191,21 @@ public class OrderableSlsVersionTests {
         assertVersionsInOrder("1.0.0-rc2", "1.0.1-rc1-3-ga");
     }
 
+    @Test
+    public void testCheckWithOrderableVersion() {
+        assertThat(OrderableSlsVersion.check("1.0.0")).isTrue();
+    }
+
+    @Test
+    public void testCheckWithNonOrderableVersion() {
+        assertThat(OrderableSlsVersion.check("1.0.0-foo")).isFalse();
+    }
+
+
+    @Test
+    public void testCheckWithGarbage() {
+        assertThat(OrderableSlsVersion.check("foo")).isFalse();
+    }
     @Test
     public void testEqualVersions() {
         assertVersionsEqual("1.0.0", "1.0.0");

--- a/sls-versions/src/test/java/com/palantir/sls/versions/SlsVersionTests.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/SlsVersionTests.java
@@ -43,4 +43,20 @@ public class SlsVersionTests {
         String serialized = mapper.writeValueAsString(version);
         assertThat(mapper.readValue(serialized, SlsVersion.class)).isEqualTo(version);
     }
+
+    @Test
+    public void testCheckWithOrderableVersion() {
+        assertThat(SlsVersion.check("1.0.0")).isTrue();
+    }
+
+    @Test
+    public void testCheckWithNonOrderableVersion() {
+        assertThat(SlsVersion.check("1.0.0-foo")).isTrue();
+    }
+
+    @Test
+    public void testCheckWithGarbage() {
+        assertThat(SlsVersion.check("foo")).isFalse();
+    }
+
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`check` is not overridden by `OrderableSlsVersion` or `NonOrderableSlsVersion`, which means it's the same as calling `SlsVersion.check` which has different expected behavior in a confusing and unexpected way.

Additionally, `SlsVersion::check` caught an `IllegalArgumentException` when what was actually being thrown was a `SafeIllegalArgumentException` in some cases.

I also cleaned up a couple of things the compiler was complaining about

## After this PR
==COMMIT_MSG==
Implement `check` method for `OrderableSlsVersion` and `NonOrderableSlsVersion` with correct semantics. Also fixes a case where this method would throw a `SafeIllegalArgumentException` unexpectedly.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

