### PR TITLE
remove jackson dep, only pull in annotations

### DIFF
--- a/sls-versions/build.gradle
+++ b/sls-versions/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile 'com.fasterxml.jackson.core:jackson-databind'
+    compile 'com.fasterxml.jackson.core:jackson-annotations'
     compile 'com.palantir.safe-logging:preconditions'
     compile 'com.palantir.safe-logging:safe-logging'
     compile 'org.slf4j:slf4j-api'
@@ -7,6 +7,7 @@ dependencies {
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'
 
+    testCompile 'com.fasterxml.jackson.core:jackson-databind'
     testCompile 'junit:junit'
     testCompile 'org.assertj:assertj-core'
     testCompile 'org.mockito:mockito-core'

--- a/versions.lock
+++ b/versions.lock
@@ -1,7 +1,5 @@
 # Run ./gradlew --write-locks to regenerate this file
-com.fasterxml.jackson.core:jackson-annotations:2.10.2 (1 constraints: 85122e21)
-com.fasterxml.jackson.core:jackson-core:2.10.2 (1 constraints: 85122e21)
-com.fasterxml.jackson.core:jackson-databind:2.10.2 (1 constraints: 3705313b)
+com.fasterxml.jackson.core:jackson-annotations:2.10.2 (2 constraints: bb179c70)
 com.google.errorprone:error_prone_annotations:2.1.3 (1 constraints: 021123c0)
 com.palantir.safe-logging:preconditions:1.4.0 (1 constraints: 0705fc35)
 com.palantir.safe-logging:safe-logging:1.13.0 (2 constraints: 371685f5)
@@ -9,6 +7,8 @@ org.immutables:value:2.8.3 (1 constraints: 0f051036)
 org.slf4j:slf4j-api:1.7.25 (1 constraints: 4105483b)
 
 [Test dependencies]
+com.fasterxml.jackson.core:jackson-core:2.10.2 (1 constraints: 85122e21)
+com.fasterxml.jackson.core:jackson-databind:2.10.2 (1 constraints: 3705313b)
 junit:junit:4.13 (1 constraints: dc040031)
 net.bytebuddy:byte-buddy:1.10.5 (1 constraints: 410b37de)
 net.bytebuddy:byte-buddy-agent:1.10.5 (1 constraints: 410b37de)


### PR DESCRIPTION
## Before this PR
We pulled in all jackson-databind so that we could get the annotations

## After this PR
Only pull in the required annotations

## Possible downsides?
N/A

