### PR TITLE
Don't throw exceptions in safeValueOf

### DIFF
--- a/changelog/@unreleased/pr-311.v2.yml
+++ b/changelog/@unreleased/pr-311.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '`OrderableSlsVersions#safeValueOf` no longer throws exceptions when
+    given a null input.'
+  links:
+  - https://github.com/palantir/sls-version-java/pull/311

--- a/sls-versions/src/main/java/com/palantir/sls/versions/NonOrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/NonOrderableSlsVersion.java
@@ -37,14 +37,18 @@ public abstract class NonOrderableSlsVersion extends SlsVersion {
     }
 
     /** The same as {@link #valueOf(String)}, but will return {@link Optional#empty()} if the format is invalid. */
-    public static Optional<NonOrderableSlsVersion> safeValueOf(String version) {
-        Matcher matcher = SlsVersionType.NON_ORDERABLE.getPattern().matcher(version);
+    public static Optional<NonOrderableSlsVersion> safeValueOf(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+
+        Matcher matcher = SlsVersionType.NON_ORDERABLE.getPattern().matcher(value);
         if (!matcher.matches()) {
             return Optional.empty();
         }
 
         return Optional.of(new NonOrderableSlsVersion.Builder()
-                .value(version)
+                .value(value)
                 .majorVersionNumber(Integer.parseInt(matcher.group(1)))
                 .minorVersionNumber(Integer.parseInt(matcher.group(2)))
                 .patchVersionNumber(Integer.parseInt(matcher.group(3)))

--- a/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
@@ -17,7 +17,6 @@
 package com.palantir.sls.versions;
 
 import static com.palantir.logsafe.Preconditions.checkArgument;
-import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -51,7 +50,10 @@ public abstract class OrderableSlsVersion extends SlsVersion {
 
     /** The same as {@link #valueOf(String)}, but will return {@link Optional#empty} if the format is invalid. */
     public static Optional<OrderableSlsVersion> safeValueOf(String value) {
-        checkNotNull(value, "value cannot be null");
+        if (value == null) {
+            return Optional.empty();
+        }
+
         SlsVersionType type = getTypeOrNull(value);
         if (type == null) {
             return Optional.empty();


### PR DESCRIPTION
## Before this PR
`OrderableSlsVersions#safeValueOf` can throw an exception if the provided value is `null`.

This caused some difficulty debugging internally because this method threw a NPE before the callers could gracefully handle the absent return value.

## After this PR
`OrderableSlsVersions#safeValueOf` does not throw exceptions and always returns `Optional.empty()` for invalid input.

Callers should be able to assume that a method named `safeValueOf` returning an `Optional` will not throw.

