### PR TITLE
OrderableSlsVersion implements Comparable

### DIFF
--- a/changelog/@unreleased/pr-400.v2.yml
+++ b/changelog/@unreleased/pr-400.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`OrderableSlsVersion` now implements `Comparable<OrderableSlsVersion>`.'
+  links:
+  - https://github.com/palantir/sls-version-java/pull/400

--- a/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
@@ -32,7 +32,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutablesStyle
-public abstract class OrderableSlsVersion extends SlsVersion {
+public abstract class OrderableSlsVersion extends SlsVersion implements Comparable<OrderableSlsVersion> {
 
     private static final SlsVersionType[] ORDERED_VERSION_TYPES = {
         SlsVersionType.RELEASE,
@@ -96,6 +96,11 @@ public abstract class OrderableSlsVersion extends SlsVersion {
     @Override
     public final String toString() {
         return getValue();
+    }
+
+    @Override
+    public final int compareTo(OrderableSlsVersion other) {
+        return VersionComparator.INSTANCE.compare(this, other);
     }
 
     public static class Builder extends ImmutableOrderableSlsVersion.Builder {}

--- a/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
@@ -110,8 +110,7 @@ public class OrderableSlsVersionTests {
     public void testVersionIsEqualToItself() {
         for (String v : ORDERABLE_VERSIONS_IN_ORDER) {
             assertThat(OrderableSlsVersion.valueOf(v)).isEqualTo(OrderableSlsVersion.valueOf(v));
-            assertThat(compare(OrderableSlsVersion.valueOf(v), OrderableSlsVersion.valueOf(v)))
-                    .isZero();
+            assertThat(OrderableSlsVersion.valueOf(v)).isEqualByComparingTo(OrderableSlsVersion.valueOf(v));
         }
     }
 
@@ -120,10 +119,8 @@ public class OrderableSlsVersionTests {
         for (int i = 0; i < ORDERABLE_VERSIONS_IN_ORDER.length - 1; ++i) {
             String left = ORDERABLE_VERSIONS_IN_ORDER[i];
             String right = ORDERABLE_VERSIONS_IN_ORDER[i + 1];
-            assertThat(compare(OrderableSlsVersion.valueOf(left), OrderableSlsVersion.valueOf(right)))
-                    .isEqualTo(-1);
-            assertThat(compare(OrderableSlsVersion.valueOf(right), OrderableSlsVersion.valueOf(left)))
-                    .isEqualTo(1);
+            assertThat(OrderableSlsVersion.valueOf(left)).isLessThan(OrderableSlsVersion.valueOf(right));
+            assertThat(OrderableSlsVersion.valueOf(right)).isGreaterThan(OrderableSlsVersion.valueOf(left));
         }
     }
 
@@ -211,12 +208,16 @@ public class OrderableSlsVersionTests {
     }
 
     private void assertVersionsInOrder(String smaller, String larger) {
-        assertThat(compare(OrderableSlsVersion.valueOf(smaller), OrderableSlsVersion.valueOf(larger)))
+        assertThat(OrderableSlsVersion.valueOf(smaller)).isLessThan(OrderableSlsVersion.valueOf(larger));
+        assertThat(VersionComparator.INSTANCE.compare(
+                        OrderableSlsVersion.valueOf(smaller), OrderableSlsVersion.valueOf(larger)))
                 .isEqualTo(-1);
     }
 
     private void assertVersionsEqual(String left, String right) {
-        assertThat(compare(OrderableSlsVersion.valueOf(left), OrderableSlsVersion.valueOf(right)))
+        assertThat(OrderableSlsVersion.valueOf(left)).isEqualByComparingTo(OrderableSlsVersion.valueOf(right));
+        assertThat(VersionComparator.INSTANCE.compare(
+                        OrderableSlsVersion.valueOf(left), OrderableSlsVersion.valueOf(right)))
                 .isZero();
     }
 
@@ -238,9 +239,5 @@ public class OrderableSlsVersionTests {
                 .secondSequenceVersionNumber(
                         secondSequence == null ? OptionalInt.empty() : OptionalInt.of(secondSequence))
                 .build();
-    }
-
-    private int compare(OrderableSlsVersion left, OrderableSlsVersion right) {
-        return VersionComparator.INSTANCE.compare(left, right);
     }
 }


### PR DESCRIPTION
## Before this PR
It is cumbersome to use `OrderableSlsVersion` with `Comparator` combinators because `OrderableSlsVersion` is not `Comparable`, even though it has a natural and canonical `Comparator` implementation.

## After this PR
`OrderableSlsVersion` implements `Comparable`.

