### PR TITLE
Use SOURCE retention for immutables style annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,13 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.palantir.javaformat:gradle-palantir-java-format:1.1.0'
-        classpath 'com.netflix.nebula:gradle-info-plugin:9.3.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+        classpath 'com.netflix.nebula:gradle-info-plugin:9.3.0'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:17.3.2'
         classpath 'com.palantir.baseline:gradle-baseline-java:3.69.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.28.0'
+        classpath 'com.palantir.gradle.revapi:gradle-revapi:1.4.4'
+        classpath 'com.palantir.javaformat:gradle-palantir-java-format:1.1.0'
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.3.0'
     }
 }
@@ -39,7 +40,6 @@ allprojects {
 subprojects {
     apply plugin: 'java-library'
     apply plugin: 'org.inferred.processors'
-    apply from: "${rootDir}/gradle/publish-jar.gradle"
 
     tasks.check.dependsOn(javadoc)
     sourceCompatibility = 1.8

--- a/sls-versions/build.gradle
+++ b/sls-versions/build.gradle
@@ -1,3 +1,6 @@
+apply from: "${rootDir}/gradle/publish-jar.gradle"
+apply plugin: 'com.palantir.revapi'
+
 dependencies {
     compile 'com.fasterxml.jackson.core:jackson-annotations'
     compile 'com.palantir.safe-logging:preconditions'

--- a/sls-versions/src/main/java/com/palantir/sls/versions/ImmutablesStyle.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/ImmutablesStyle.java
@@ -23,7 +23,7 @@ import java.lang.annotation.Target;
 import org.immutables.value.Value;
 
 @Target({ElementType.PACKAGE, ElementType.TYPE})
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.SOURCE)
 @Value.Style(
         visibility = Value.Style.ImplementationVisibility.PACKAGE,
         overshadowImplementation = true,


### PR DESCRIPTION
See https://github.com/immutables/immutables/issues/291.

Example of a similar fix in https://github.com/palantir/conjure-java-runtime/pull/1897.

This eliminates compilation warnings for consumers that do not directly depend on immutables.