### PR TITLE
Eliminate exceptions from SlsVersionMatcher#safeValueOf using guava's Ints.tryparse

### DIFF
--- a/changelog/@unreleased/pr-456.v2.yml
+++ b/changelog/@unreleased/pr-456.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '`SlsVersionMatcher#safeValueOf` no longer involves throwing and catching
+    exceptions as part of its normal behaviour.'
+  links:
+  - https://github.com/palantir/sls-version-java/pull/456

--- a/sls-versions/build.gradle
+++ b/sls-versions/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     compile 'com.palantir.safe-logging:preconditions'
     compile 'com.palantir.safe-logging:safe-logging'
     compile 'org.slf4j:slf4j-api'
+    implementation 'com.google.guava:guava'
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'

--- a/versions.lock
+++ b/versions.lock
@@ -1,8 +1,14 @@
 # Run ./gradlew --write-locks to regenerate this file
 com.fasterxml.jackson.core:jackson-annotations:2.11.1 (2 constraints: bb17a070)
-com.google.errorprone:error_prone_annotations:2.1.3 (1 constraints: 021123c0)
+com.google.code.findbugs:jsr305:3.0.2 (1 constraints: 170aecb4)
+com.google.errorprone:error_prone_annotations:2.5.1 (2 constraints: 1b1bf559)
+com.google.guava:failureaccess:1.0.1 (1 constraints: 140ae1b4)
+com.google.guava:guava:30.1.1-jre (1 constraints: a5064e53)
+com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
+com.google.j2objc:j2objc-annotations:1.3 (1 constraints: b809eda0)
 com.palantir.safe-logging:preconditions:1.4.0 (1 constraints: 0705fc35)
 com.palantir.safe-logging:safe-logging:1.14.0 (2 constraints: 3816b8f5)
+org.checkerframework:checker-qual:3.8.0 (1 constraints: 1d0a02b5)
 org.immutables:value:2.8.8 (1 constraints: 14051536)
 org.slf4j:slf4j-api:1.7.30 (1 constraints: 3d05453b)
 

--- a/versions.props
+++ b/versions.props
@@ -3,6 +3,7 @@ org.immutables:* = 2.8.8
 org.slf4j:slf4j-api = 1.7.30
 com.palantir.safe-logging:preconditions = 1.4.0
 com.palantir.safe-logging:safe-logging = 1.14.0
+com.google.guava:guava = 30.1.1-jre
 
 # Test dependencies
 junit:junit = 4.13.2


### PR DESCRIPTION
## Before this PR

Same motivation as https://github.com/palantir/sls-version-java/pull/455

## After this PR
==COMMIT_MSG==
`SlsVersionMatcher#safeValueOf` no longer involves throwing and catching exceptions as part of its normal behaviour.
==COMMIT_MSG==

## Possible downsides?
- this is taking a guava dependency. the slsversion class gets used in quite a few APIs, so this might impose guava upgrades on consumers.

