### PR TITLE
Hand rolled parser for SlsVersionType.RELEASE (aka x.y.z)

### DIFF
--- a/changelog/@unreleased/pr-463.v2.yml
+++ b/changelog/@unreleased/pr-463.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Parsing the simplest `x.y.z` type of `OrderableSlsVersion` no longer
+    uses regexes. Allocation is reduced from ~600 bytes/op -> ~128bytes/op.
+  links:
+  - https://github.com/palantir/sls-version-java/pull/463

--- a/changelog/@unreleased/pr-463.v2.yml
+++ b/changelog/@unreleased/pr-463.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
   description: Parsing the simplest `x.y.z` type of `OrderableSlsVersion` no longer
-    uses regexes. Allocation is reduced from ~600 bytes/op -> ~128bytes/op.
+    uses regexes. Allocation is reduced by about 75%
   links:
   - https://github.com/palantir/sls-version-java/pull/463

--- a/sls-versions/src/main/java/com/palantir/sls/versions/MatchResult.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/MatchResult.java
@@ -19,6 +19,8 @@ package com.palantir.sls.versions;
 import java.util.regex.Matcher;
 
 interface MatchResult {
+
+    /** 1-indexed, to match java regexes. */
     int groupAsInt(int group);
 
     int groupCount();

--- a/sls-versions/src/main/java/com/palantir/sls/versions/MatchResult.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/MatchResult.java
@@ -1,0 +1,73 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.sls.versions;
+
+import java.util.regex.Matcher;
+
+interface MatchResult {
+    int groupAsInt(int group);
+
+    int groupCount();
+
+    final class RegexMatchResult implements MatchResult {
+        private final Matcher matcher;
+
+        RegexMatchResult(Matcher matcher) {
+            this.matcher = matcher;
+        }
+
+        @Override
+        public int groupAsInt(int group) {
+            return Integer.parseInt(matcher.group(group));
+        }
+
+        @Override
+        public int groupCount() {
+            return matcher.groupCount();
+        }
+    }
+
+    final class Int3MatchResult implements MatchResult {
+        private final int first;
+        private final int second;
+        private final int third;
+
+        Int3MatchResult(int first, int second, int third) {
+            this.first = first;
+            this.second = second;
+            this.third = third;
+        }
+
+        @Override
+        public int groupAsInt(int group) {
+            switch (group) {
+                case 1:
+                    return first;
+                case 2:
+                    return second;
+                case 3:
+                    return third;
+            }
+            throw new IndexOutOfBoundsException();
+        }
+
+        @Override
+        public int groupCount() {
+            return 3;
+        }
+    }
+}

--- a/sls-versions/src/main/java/com/palantir/sls/versions/NonOrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/NonOrderableSlsVersion.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.UnsafeArg;
 import java.util.Optional;
-import java.util.regex.MatchResult;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -49,9 +48,9 @@ public abstract class NonOrderableSlsVersion extends SlsVersion {
 
         return Optional.of(new NonOrderableSlsVersion.Builder()
                 .value(value)
-                .majorVersionNumber(Integer.parseInt(groups.group(1)))
-                .minorVersionNumber(Integer.parseInt(groups.group(2)))
-                .patchVersionNumber(Integer.parseInt(groups.group(3)))
+                .majorVersionNumber(groups.groupAsInt(1))
+                .minorVersionNumber(groups.groupAsInt(2))
+                .patchVersionNumber(groups.groupAsInt(3))
                 .type(SlsVersionType.NON_ORDERABLE)
                 .build());
     }

--- a/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.UnsafeArg;
 import java.util.Optional;
-import java.util.regex.MatchResult;
 import org.immutables.value.Value;
 
 /**
@@ -67,15 +66,15 @@ public abstract class OrderableSlsVersion extends SlsVersion implements Comparab
         OrderableSlsVersion.Builder orderableSlsVersion = new Builder()
                 .type(type)
                 .value(value)
-                .majorVersionNumber(Integer.parseInt(groups.group(1)))
-                .minorVersionNumber(Integer.parseInt(groups.group(2)))
-                .patchVersionNumber(Integer.parseInt(groups.group(3)));
+                .majorVersionNumber(groups.groupAsInt(1))
+                .minorVersionNumber(groups.groupAsInt(2))
+                .patchVersionNumber(groups.groupAsInt(3));
 
         if (groups.groupCount() >= 4) {
-            orderableSlsVersion.firstSequenceVersionNumber(Integer.parseInt(groups.group(4)));
+            orderableSlsVersion.firstSequenceVersionNumber(groups.groupAsInt(4));
         }
         if (groups.groupCount() >= 5) {
-            orderableSlsVersion.secondSequenceVersionNumber(Integer.parseInt(groups.group(5)));
+            orderableSlsVersion.secondSequenceVersionNumber(groups.groupAsInt(5));
         }
 
         return orderableSlsVersion.build();

--- a/sls-versions/src/main/java/com/palantir/sls/versions/Parser.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/Parser.java
@@ -23,8 +23,10 @@ import javax.annotation.Nullable;
 @Immutable
 interface Parser {
 
+    /** Returns a {@link MatchResult} if the provided string matches the pattern, or null otherwise. */
     @Nullable
     MatchResult tryParse(String string);
 
+    /** An equivalent java regex. */
     Pattern getPattern();
 }

--- a/sls-versions/src/main/java/com/palantir/sls/versions/Parser.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/Parser.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.sls.versions;
+
+import com.google.errorprone.annotations.Immutable;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+@Immutable
+interface Parser {
+
+    @Nullable
+    MatchResult tryParse(String string);
+
+    Pattern getPattern();
+}

--- a/sls-versions/src/main/java/com/palantir/sls/versions/Parsers.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/Parsers.java
@@ -1,0 +1,124 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.sls.versions;
+
+/**
+ * We're using parser combinator-style ideas here, where each parser function {@link Parsers#numberOrX},
+ * {@link Parsers#number}, {@link Parsers#literalX} accepts an index into our source string and returns a two values:
+ *
+ * - an updated index into the string representing how many characters were parsed
+ * - a value that was actually parsed out of the string (if the parser was able to parse the string), otherwise a
+ * clear signal that the parser failed (we use {@link Integer#MIN_VALUE} for this.
+ *
+ * We bit-pack these two integer values into a single long using {@link Parsers#ok} and {@link Parsers#fail} functions
+ * because primitive longs live on the stack and don't impact GC.
+ */
+final class Parsers {
+
+    static final int MAGIC_X_NUMBER = -1;
+    private static final long INT_MASK = (1L << 32) - 1;
+
+    private Parsers() {}
+
+    // "x" is signified by the magic negative number -1, which is distinct from Integer.MIN_VALUE which is a failure
+    static long numberOrX(String string, int startIndex) {
+        long xResult = literalX(string, startIndex);
+        if (isOk(xResult)) {
+            return ok(getIndex(xResult), MAGIC_X_NUMBER);
+        }
+
+        long numberResult = number(string, startIndex);
+        if (isOk(numberResult)) {
+            return numberResult;
+        }
+
+        return fail(startIndex);
+    }
+
+    static long number(String string, int startIndex) {
+        int next = startIndex;
+        int len = string.length();
+        while (next < len) {
+            int codepoint = string.codePointAt(next);
+            if (Character.isDigit(codepoint)) {
+                next += 1;
+            } else {
+                break;
+            }
+        }
+        if (next == startIndex) {
+            return fail(startIndex);
+        } else if (next == startIndex + 1) {
+            return ok(next, Character.digit(string.codePointAt(startIndex), 10));
+        } else {
+            try {
+                return ok(next, Integer.parseUnsignedInt(string.substring(startIndex, next)));
+            } catch (NumberFormatException e) {
+                if (e.getMessage() != null && e.getMessage().endsWith("exceeds range of unsigned int.")) {
+                    return fail(startIndex);
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    // 0 signifies success
+    private static long literalX(String string, int startIndex) {
+        if (startIndex < string.length() && string.codePointAt(startIndex) == 'x') {
+            return ok(startIndex + 1, 0);
+        } else {
+            return fail(startIndex);
+        }
+    }
+
+    static long literalDot(String string, int startIndex) {
+        if (startIndex < string.length() && string.codePointAt(startIndex) == '.') {
+            return ok(startIndex + 1, 0);
+        } else {
+            return fail(startIndex);
+        }
+    }
+
+    /**
+     * We are bit-packing two integers into a single long.  The 'index' occupies half of the bits and the 'result'
+     * occupies the other half.
+     */
+    static long ok(int index, int result) {
+        return ((long) index) << 32 | (result & INT_MASK);
+    }
+
+    static long fail(int index) {
+        return ((long) index) << 32 | (Integer.MIN_VALUE & INT_MASK);
+    }
+
+    static boolean isOk(long state) {
+        return getResult(state) != Integer.MIN_VALUE;
+    }
+
+    static boolean failed(long state) {
+        return !isOk(state);
+    }
+
+    static int getResult(long state) {
+        return (int) (state & INT_MASK);
+    }
+
+    static int getIndex(long state) {
+        return (int) (state >>> 32);
+    }
+}

--- a/sls-versions/src/main/java/com/palantir/sls/versions/Parsers.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/Parsers.java
@@ -31,6 +31,7 @@ final class Parsers {
 
     static final int MAGIC_X_NUMBER = -1;
     private static final long INT_MASK = (1L << 32) - 1;
+    private static final int PARSE_FAILED = Integer.MIN_VALUE;
 
     private Parsers() {}
 
@@ -103,11 +104,11 @@ final class Parsers {
     }
 
     static long fail(int index) {
-        return ((long) index) << 32 | (Integer.MIN_VALUE & INT_MASK);
+        return ((long) index) << 32 | (PARSE_FAILED & INT_MASK);
     }
 
     static boolean isOk(long state) {
-        return getResult(state) != Integer.MIN_VALUE;
+        return getResult(state) != PARSE_FAILED;
     }
 
     static boolean failed(long state) {

--- a/sls-versions/src/main/java/com/palantir/sls/versions/RegexParser.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/RegexParser.java
@@ -17,7 +17,6 @@
 package com.palantir.sls.versions;
 
 import com.google.errorprone.annotations.Immutable;
-import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -27,7 +26,7 @@ import javax.annotation.Nullable;
  * {@link Matcher#matches} multiple times.
  */
 @Immutable
-final class RegexParser {
+final class RegexParser implements Parser {
     private final Pattern pattern;
 
     RegexParser(Pattern pattern) {
@@ -40,13 +39,15 @@ final class RegexParser {
     }
 
     /** Returns a {@link MatchResult} if the provided string matches the pattern, or null otherwise. */
+    @Override
     @Nullable
-    MatchResult tryParse(String string) {
+    public MatchResult tryParse(String string) {
         Matcher matcher = pattern.matcher(string);
-        return matcher.matches() ? matcher : null;
+        return matcher.matches() ? new MatchResult.RegexMatchResult(matcher) : null;
     }
 
-    Pattern getPattern() {
+    @Override
+    public Pattern getPattern() {
         return pattern;
     }
 }

--- a/sls-versions/src/main/java/com/palantir/sls/versions/ReleaseVersionParser.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/ReleaseVersionParser.java
@@ -1,0 +1,70 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.sls.versions;
+
+import com.google.errorprone.annotations.Immutable;
+import com.palantir.sls.versions.MatchResult.Int3MatchResult;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+@Immutable
+enum ReleaseVersionParser implements Parser {
+    INSTANCE;
+
+    @Nullable
+    @Override
+    public MatchResult tryParse(String string) {
+        long state = Parsers.number(string, 0);
+        if (Parsers.failed(state)) {
+            return null;
+        }
+        int first = Parsers.getResult(state);
+
+        state = Parsers.literalDot(string, Parsers.getIndex(state));
+        if (Parsers.failed(state)) {
+            return null;
+        }
+
+        state = Parsers.number(string, Parsers.getIndex(state));
+        if (Parsers.failed(state)) {
+            return null;
+        }
+        int second = Parsers.getResult(state);
+
+        state = Parsers.literalDot(string, Parsers.getIndex(state));
+        if (Parsers.failed(state)) {
+            return null;
+        }
+
+        state = Parsers.number(string, Parsers.getIndex(state));
+        if (Parsers.failed(state)) {
+            return null;
+        }
+        int third = Parsers.getResult(state);
+
+        if (Parsers.getIndex(state) < string.length()) {
+            return null; // reject due to trailing stuff
+        }
+
+        return new Int3MatchResult(first, second, third);
+    }
+
+    @Override
+    public Pattern getPattern() {
+        return Pattern.compile("^([0-9]+)\\.([0-9]+)\\.([0-9]+)$");
+    }
+}

--- a/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersionMatcherParser.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersionMatcherParser.java
@@ -21,20 +21,8 @@ import java.util.OptionalInt;
 
 /**
  * A hand-rolled implementation of {@code RegexSlsVersionMatcherParser}.
- *
- * We're using parser combinator-style ideas here, where each parser function {@link #numberOrX}, {@link #number},
- * {@link #literalX} accepts an index into our source string and returns a two values:
- *
- * - an updated index into the string representing how many characters were parsed
- * - a value that was actually parsed out of the string (if the parser was able to parse the string), otherwise a
- * clear signal that the parser failed (we use {@link Integer#MIN_VALUE} for this.
- *
- * We bit-pack these two integer values into a single long using {@link #ok} and {@link #fail} functions because
- * primitive longs live on the stack and don't impact GC.
  */
 final class SlsVersionMatcherParser {
-
-    private static final int MAGIC_X_NUMBER = -1;
 
     public static Optional<SlsVersionMatcher> safeValueOf(String string) {
         OptionalInt major = OptionalInt.empty();
@@ -42,140 +30,49 @@ final class SlsVersionMatcherParser {
         OptionalInt patch = OptionalInt.empty();
 
         // major
-        long result = numberOrX(string, 0);
-        if (failed(result)) {
+        long result = Parsers.numberOrX(string, 0);
+        if (Parsers.failed(result)) {
             return Optional.empty(); // reject
         }
-        if (getResult(result) != MAGIC_X_NUMBER) {
-            major = OptionalInt.of(getResult(result));
+        if (Parsers.getResult(result) != Parsers.MAGIC_X_NUMBER) {
+            major = OptionalInt.of(Parsers.getResult(result));
         }
 
         // dot
-        result = literalDot(string, getIndex(result));
-        if (failed(result)) {
+        result = Parsers.literalDot(string, Parsers.getIndex(result));
+        if (Parsers.failed(result)) {
             return Optional.empty();
         }
 
         // minor
-        result = numberOrX(string, getIndex(result));
-        if (failed(result)) {
+        result = Parsers.numberOrX(string, Parsers.getIndex(result));
+        if (Parsers.failed(result)) {
             return Optional.empty(); // reject
         }
-        if (getResult(result) != MAGIC_X_NUMBER) {
-            minor = OptionalInt.of(getResult(result));
+        if (Parsers.getResult(result) != Parsers.MAGIC_X_NUMBER) {
+            minor = OptionalInt.of(Parsers.getResult(result));
         }
 
         // dot
-        result = literalDot(string, getIndex(result));
-        if (failed(result)) {
+        result = Parsers.literalDot(string, Parsers.getIndex(result));
+        if (Parsers.failed(result)) {
             return Optional.empty();
         }
 
         // patch
-        result = numberOrX(string, getIndex(result));
-        if (failed(result)) {
+        result = Parsers.numberOrX(string, Parsers.getIndex(result));
+        if (Parsers.failed(result)) {
             return Optional.empty(); // reject
         }
-        if (getResult(result) != MAGIC_X_NUMBER) {
-            patch = OptionalInt.of(getResult(result));
+        if (Parsers.getResult(result) != Parsers.MAGIC_X_NUMBER) {
+            patch = OptionalInt.of(Parsers.getResult(result));
         }
 
-        if (getIndex(result) < string.length()) {
+        if (Parsers.getIndex(result) < string.length()) {
             return Optional.empty(); // reject due to trailing stuff
         }
 
         return SlsVersionMatcher.maybeCreate(string, major, minor, patch);
-    }
-
-    // "x" is signified by the magic negative number -1, which is distinct from Integer.MIN_VALUE which is a failure
-    private static long numberOrX(String string, int startIndex) {
-        long xResult = literalX(string, startIndex);
-        if (isOk(xResult)) {
-            return ok(getIndex(xResult), MAGIC_X_NUMBER);
-        }
-
-        long numberResult = number(string, startIndex);
-        if (isOk(numberResult)) {
-            return numberResult;
-        }
-
-        return fail(startIndex);
-    }
-
-    private static long number(String string, int startIndex) {
-        int next = startIndex;
-        int len = string.length();
-        while (next < len) {
-            int codepoint = string.codePointAt(next);
-            if (Character.isDigit(codepoint)) {
-                next += 1;
-            } else {
-                break;
-            }
-        }
-        if (next == startIndex) {
-            return fail(startIndex);
-        } else if (next == startIndex + 1) {
-            return ok(next, Character.digit(string.codePointAt(startIndex), 10));
-        } else {
-            try {
-                return ok(next, Integer.parseUnsignedInt(string.substring(startIndex, next)));
-            } catch (NumberFormatException e) {
-                String message = e.getMessage();
-                if (message != null && message.endsWith("exceeds range of unsigned int.")) {
-                    return fail(startIndex);
-                } else {
-                    throw e;
-                }
-            }
-        }
-    }
-
-    // 0 signifies success
-    private static long literalX(String string, int startIndex) {
-        if (startIndex < string.length() && string.codePointAt(startIndex) == 'x') {
-            return ok(startIndex + 1, 0);
-        } else {
-            return fail(startIndex);
-        }
-    }
-
-    private static long literalDot(String string, int startIndex) {
-        if (startIndex < string.length() && string.codePointAt(startIndex) == '.') {
-            return ok(startIndex + 1, 0);
-        } else {
-            return fail(startIndex);
-        }
-    }
-
-    private static final long INT_MASK = (1L << 32) - 1;
-
-    /**
-     * We are bit-packing two integers into a single long.  The 'index' occupies half of the bits and the 'result'
-     * occupies the other half.
-     */
-    static long ok(int index, int result) {
-        return ((long) index) << 32 | (result & INT_MASK);
-    }
-
-    static long fail(int index) {
-        return ((long) index) << 32 | (Integer.MIN_VALUE & INT_MASK);
-    }
-
-    static boolean isOk(long state) {
-        return getResult(state) != Integer.MIN_VALUE;
-    }
-
-    static boolean failed(long state) {
-        return !isOk(state);
-    }
-
-    static int getResult(long state) {
-        return (int) (state & INT_MASK);
-    }
-
-    static int getIndex(long state) {
-        return (int) (state >>> 32);
     }
 
     private SlsVersionMatcherParser() {}

--- a/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersionType.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersionType.java
@@ -24,24 +24,24 @@ import java.util.regex.Pattern;
  */
 public enum SlsVersionType {
     RELEASE_SNAPSHOT(RegexParser.of("^([0-9]+)\\.([0-9]+)\\.([0-9]+)-([0-9]+)-g[a-f0-9]+$"), 4),
-    RELEASE(RegexParser.of("^([0-9]+)\\.([0-9]+)\\.([0-9]+)$"), 3),
+    RELEASE(ReleaseVersionParser.INSTANCE, 3),
     RELEASE_CANDIDATE_SNAPSHOT(RegexParser.of("^([0-9]+)\\.([0-9]+)\\.([0-9]+)-rc([0-9]+)-([0-9]+)-g[a-f0-9]+$"), 2),
     RELEASE_CANDIDATE(RegexParser.of("^([0-9]+)\\.([0-9]+)\\.([0-9]+)-rc([0-9]+)$"), 1),
     NON_ORDERABLE(RegexParser.of("^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-[a-z0-9-]+)?(\\.dirty)?$"), 0);
 
-    private final RegexParser regexParser;
+    private final Parser parser;
     private final int priority;
 
     public Pattern getPattern() {
-        return regexParser.getPattern();
+        return parser.getPattern();
     }
 
-    RegexParser getParser() {
-        return regexParser;
+    Parser getParser() {
+        return parser;
     }
 
-    SlsVersionType(RegexParser regexParser, int priority) {
-        this.regexParser = regexParser;
+    SlsVersionType(Parser parser, int priority) {
+        this.parser = parser;
         this.priority = priority;
     }
 


### PR DESCRIPTION
## Before this PR: 416 bytes / op

From 1 minute JFR, the hottest method in my application is currently `java.util.regex`, and the biggest proportion of these Matcher constructions are coming from the lovely `OrderableSlsVersion#safeValueOf`

![image](https://user-images.githubusercontent.com/3473798/122296063-dde2ca80-cef1-11eb-9eab-6158c2e49401.png)

This seems a bit silly, given that most of the time we're trying to parse three numbers with dots in between them.

```
Benchmark                                                         (versionString)  Mode  Cnt     Score      Error   Units
SlsVersionBenchmark.safeValueOf                                           RELEASE  avgt    3   176.778 ±   30.231   ns/op
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate                            RELEASE  avgt    3  7690.289 ± 1225.982  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate.norm                       RELEASE  avgt    3   416.021 ±    0.007    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space                   RELEASE  avgt    3  7751.897 ± 1363.284  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space.norm              RELEASE  avgt    3   419.352 ±   10.138    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Survivor_Space               RELEASE  avgt    3     0.035 ±    0.064  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Survivor_Space.norm          RELEASE  avgt    3     0.002 ±    0.004    B/op
SlsVersionBenchmark.safeValueOf:·gc.count                                 RELEASE  avgt    3   184.000             counts
SlsVersionBenchmark.safeValueOf:·gc.time                                  RELEASE  avgt    3   103.000                 ms
```

## After this PR: 104 bytes / op
==COMMIT_MSG==
Deserializing a verison of the form `x.y.z` now allocates less. This should mean GC algorithms have less work to do.
==COMMIT_MSG==

```

Benchmark                                                         (versionString)  Mode  Cnt     Score       Error   Units
SlsVersionBenchmark.safeValueOf                                           RELEASE  avgt    3    55.592 ±   109.978   ns/op
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate                            RELEASE  avgt    3  6158.567 ± 11630.568  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate.norm                       RELEASE  avgt    3   104.006 ±     0.002    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space                   RELEASE  avgt    3  6200.873 ± 12743.698  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space.norm              RELEASE  avgt    3   104.656 ±    22.149    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Survivor_Space               RELEASE  avgt    3     0.019 ±     0.067  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Survivor_Space.norm          RELEASE  avgt    3    ≈ 10⁻³                B/op
SlsVersionBenchmark.safeValueOf:·gc.count                                 RELEASE  avgt    3   147.000              counts
SlsVersionBenchmark.safeValueOf:·gc.time                                  RELEASE  avgt    3    88.000                  ms
```
## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

