### PR TITLE
[break] Stop using Matcher.group() which allocates a string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
     apply plugin: 'org.inferred.processors'
 
     tasks.check.dependsOn(javadoc)
-    sourceCompatibility = 1.8
+    sourceCompatibility = 11
 
     tasks.withType(JavaCompile) {
         options.compilerArgs += ['-Werror']

--- a/changelog/@unreleased/pr-466.v2.yml
+++ b/changelog/@unreleased/pr-466.v2.yml
@@ -1,7 +1,6 @@
 type: break
 break:
-  description: This library no longer runs on Java 8 and requires Java 11. This allows
-    parsing of all types of sls version to no longer involve allocating strings just
-    to parse them as integers again.
+  description: This library now requires Java 11+ (previously it could run on Java
+    8+). This allows us to eliminate some String allocations from parsing SLS versions.
   links:
   - https://github.com/palantir/sls-version-java/pull/466

--- a/changelog/@unreleased/pr-466.v2.yml
+++ b/changelog/@unreleased/pr-466.v2.yml
@@ -1,0 +1,7 @@
+type: break
+break:
+  description: This library no longer runs on Java 8 and requires Java 11. This allows
+    parsing of all types of sls version to no longer involve allocating strings just
+    to parse them as integers again.
+  links:
+  - https://github.com/palantir/sls-version-java/pull/466

--- a/sls-versions/src/main/java/com/palantir/sls/versions/MatchResult.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/MatchResult.java
@@ -26,15 +26,28 @@ interface MatchResult {
     int groupCount();
 
     final class RegexMatchResult implements MatchResult {
+        private static final int RADIX = 10;
+        private final String string;
         private final Matcher matcher;
 
-        RegexMatchResult(Matcher matcher) {
+        RegexMatchResult(String string, Matcher matcher) {
+            this.string = string;
             this.matcher = matcher;
         }
 
         @Override
         public int groupAsInt(int group) {
-            return Integer.parseInt(matcher.group(group));
+            int groupStart = matcher.start(group);
+            int groupEnd = matcher.end(group);
+            if (groupStart == -1) {
+                throw new NumberFormatException();
+            }
+
+            if (groupEnd - groupStart == 1) {
+                return Character.digit(string.codePointAt(groupStart), RADIX);
+            }
+
+            return Integer.parseUnsignedInt(string, groupStart, groupEnd, RADIX);
         }
 
         @Override

--- a/sls-versions/src/main/java/com/palantir/sls/versions/MatchResult.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/MatchResult.java
@@ -43,10 +43,6 @@ interface MatchResult {
                 throw new NumberFormatException();
             }
 
-            if (groupEnd - groupStart == 1) {
-                return Character.digit(string.codePointAt(groupStart), RADIX);
-            }
-
             return Integer.parseUnsignedInt(string, groupStart, groupEnd, RADIX);
         }
 

--- a/sls-versions/src/main/java/com/palantir/sls/versions/RegexParser.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/RegexParser.java
@@ -43,7 +43,7 @@ final class RegexParser implements Parser {
     @Nullable
     public MatchResult tryParse(String string) {
         Matcher matcher = pattern.matcher(string);
-        return matcher.matches() ? new MatchResult.RegexMatchResult(matcher) : null;
+        return matcher.matches() ? new MatchResult.RegexMatchResult(string, matcher) : null;
     }
 
     @Override


### PR DESCRIPTION
## Before this PR

For all our SlsVersionTypes:

```
    RELEASE_SNAPSHOT(Pattern.compile("^([0-9]+)\\.([0-9]+)\\.([0-9]+)-([0-9]+)-g[a-f0-9]+$"), 4),
    RELEASE(Pattern.compile("^([0-9]+)\\.([0-9]+)\\.([0-9]+)$"), 3),
    RELEASE_CANDIDATE_SNAPSHOT(Pattern.compile("^([0-9]+)\\.([0-9]+)\\.([0-9]+)-rc([0-9]+)-([0-9]+)-g[a-f0-9]+$"), 2),
    RELEASE_CANDIDATE(Pattern.compile("^([0-9]+)\\.([0-9]+)\\.([0-9]+)-rc([0-9]+)$"), 1),
    NON_ORDERABLE(Pattern.compile("^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-[a-z0-9-]+)?(\\.dirty)?$"), 0);
```

We end up calling some code like:

```
OrderableSlsVersion.Builder orderableSlsVersion = new Builder()
                .type(type)
                .value(value)
                .majorVersionNumber(groups.groupAsInt(1))
                .minorVersionNumber(groups.groupAsInt(2))
                .patchVersionNumber(groups.groupAsInt(3));
```

Where each of those `groupAsInt` calls ends up allocating a string, and then immediately passing it on to the Integer.parseInt function. This enables my application to allocate a ton of strings really fast, which causes the poor GC algorithm to do work to get rid of them again. This is one of the top causes of allocation in my product.

![image](https://user-images.githubusercontent.com/3473798/122304943-f35df180-cefd-11eb-8dbf-70f37d2bb7c1.png)

## After this PR
==COMMIT_MSG==
Parsing all types of sls version no longer involves allocating strings just to parse them as integers again.
==COMMIT_MSG==

## Possible downsides?
- We have to bump from java 8 -> java 11 bytecode in order to get the `Integer.parseUnsignedInt(string, groupStart, groupEnd, RADIX);` method (which was added in java 9)

