### PR TITLE
Avoid unnecessary substring invocations while parsing sls versions

### DIFF
--- a/changelog/@unreleased/pr-488.v2.yml
+++ b/changelog/@unreleased/pr-488.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid unnecessary substring invocations while parsing sls versions
+  links:
+  - https://github.com/palantir/sls-version-java/pull/488

--- a/sls-versions/build.gradle
+++ b/sls-versions/build.gradle
@@ -18,8 +18,7 @@ dependencies {
     testImplementation 'net.jqwik:jqwik-api'
     testRuntimeOnly 'net.jqwik:jqwik'
 
-    annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
-    compileOnly 'org.openjdk.jmh:jmh-generator-annprocess'
+    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
     jmh 'org.openjdk.jmh:jmh-core'
     jmh project(':sls-versions')
     jmh 'org.apache.logging.log4j:log4j-slf4j-impl'

--- a/sls-versions/src/main/java/com/palantir/sls/versions/Parsers.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/Parsers.java
@@ -67,7 +67,7 @@ final class Parsers {
             return ok(next, Character.digit(string.codePointAt(startIndex), 10));
         } else {
             try {
-                return ok(next, Integer.parseUnsignedInt(string.substring(startIndex, next)));
+                return ok(next, Integer.parseUnsignedInt(string, startIndex, next, 10));
             } catch (NumberFormatException e) {
                 if (e.getMessage() != null && e.getMessage().endsWith("exceeds range of unsigned int.")) {
                     return fail(startIndex);

--- a/versions.lock
+++ b/versions.lock
@@ -7,11 +7,7 @@ com.palantir.safe-logging:logger-slf4j:1.18.0 (1 constraints: 350e9350)
 com.palantir.safe-logging:logger-spi:1.18.0 (2 constraints: 791e0cb1)
 com.palantir.safe-logging:preconditions:1.18.0 (1 constraints: 3c05413b)
 com.palantir.safe-logging:safe-logging:1.18.0 (4 constraints: 52342904)
-net.sf.jopt-simple:jopt-simple:4.6 (1 constraints: 610a91b7)
-org.apache.commons:commons-math3:3.2 (1 constraints: 5c0a8ab7)
 org.immutables:value:2.8.8 (1 constraints: 14051536)
-org.openjdk.jmh:jmh-core:1.32 (1 constraints: 1411a7be)
-org.openjdk.jmh:jmh-generator-annprocess:1.32 (1 constraints: da04f730)
 org.slf4j:slf4j-api:1.7.31 (1 constraints: 471091b6)
 
 [Test dependencies]


### PR DESCRIPTION
Benchmarks using azul zulu: JDK 11.0.11, OpenJDK 64-Bit Server VM, 11.0.11+9-LTS

Before:
```
Benchmark                                                     (versionString)  Mode  Cnt     Score      Error   Units
SlsVersionBenchmark.safeValueOf                                       RELEASE  avgt    3    50.207 ±   19.752   ns/op
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate                        RELEASE  avgt    3  6770.523 ± 2701.069  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate.norm                   RELEASE  avgt    3   104.000 ±    0.002    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space               RELEASE  avgt    3  6710.234 ± 4937.252  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space.norm          RELEASE  avgt    3   103.049 ±   37.047    B/op
SlsVersionBenchmark.safeValueOf:·gc.count                             RELEASE  avgt    3    43.000             counts
SlsVersionBenchmark.safeValueOf:·gc.time                              RELEASE  avgt    3    44.000                 ms
SlsVersionBenchmark.safeValueOf                                      SNAPSHOT  avgt    3   486.891 ±  102.666   ns/op
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate                       SNAPSHOT  avgt    3  5262.779 ± 1112.242  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate.norm                  SNAPSHOT  avgt    3   784.000 ±    0.005    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space              SNAPSHOT  avgt    3  5310.614 ±   12.258  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space.norm         SNAPSHOT  avgt    3   791.197 ±  167.795    B/op
SlsVersionBenchmark.safeValueOf:·gc.count                            SNAPSHOT  avgt    3    45.000             counts
SlsVersionBenchmark.safeValueOf:·gc.time                             SNAPSHOT  avgt    3    38.000                 ms
SlsVersionBenchmark.safeValueOf                                            RC  avgt    3   185.164 ±   57.368   ns/op
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate                             RC  avgt    3  6072.004 ± 1862.317  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate.norm                        RC  avgt    3   344.000 ±    0.002    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space                    RC  avgt    3  6076.001 ±   14.374  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space.norm               RC  avgt    3   344.292 ±  106.698    B/op
SlsVersionBenchmark.safeValueOf:·gc.count                                  RC  avgt    3    51.000             counts
SlsVersionBenchmark.safeValueOf:·gc.time                                   RC  avgt    3    48.000                 ms
SlsVersionBenchmark.safeValueOf                                   RC_SNAPSHOT  avgt    3   555.801 ±  312.231   ns/op
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate                    RC_SNAPSHOT  avgt    3  4141.729 ± 2341.172  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate.norm               RC_SNAPSHOT  avgt    3   704.001 ±    0.015    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space           RC_SNAPSHOT  avgt    3  4125.168 ±    8.404  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space.norm      RC_SNAPSHOT  avgt    3   701.632 ±  394.092    B/op
SlsVersionBenchmark.safeValueOf:·gc.count                         RC_SNAPSHOT  avgt    3    42.000             counts
SlsVersionBenchmark.safeValueOf:·gc.time                          RC_SNAPSHOT  avgt    3    26.000                 ms
SlsVersionBenchmark.safeValueOf                                         DIRTY  avgt    3   416.384 ±  183.478   ns/op
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate                          DIRTY  avgt    3  5527.578 ± 2438.134  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate.norm                     DIRTY  avgt    3   704.000 ±    0.004    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space                 DIRTY  avgt    3  5445.917 ± 3747.296  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space.norm            DIRTY  avgt    3   693.877 ±  568.072    B/op
SlsVersionBenchmark.safeValueOf:·gc.count                               DIRTY  avgt    3    46.000             counts
SlsVersionBenchmark.safeValueOf:·gc.time                                DIRTY  avgt    3    41.000                 ms
```

After
```
Benchmark                                                     (versionString)  Mode  Cnt     Score      Error   Units
SlsVersionBenchmark.safeValueOf                                       RELEASE  avgt    3    30.544 ±    7.876   ns/op
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate                        RELEASE  avgt    3  5991.997 ± 1528.742  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate.norm                   RELEASE  avgt    3    56.000 ±    0.001    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space               RELEASE  avgt    3  5973.931 ± 4402.871  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space.norm          RELEASE  avgt    3    55.836 ±   41.712    B/op
SlsVersionBenchmark.safeValueOf:·gc.count                             RELEASE  avgt    3    43.000             counts
SlsVersionBenchmark.safeValueOf:·gc.time                              RELEASE  avgt    3    40.000                 ms
SlsVersionBenchmark.safeValueOf                                      SNAPSHOT  avgt    3   438.095 ±  183.560   ns/op
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate                       SNAPSHOT  avgt    3  5491.656 ± 2306.873  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate.norm                  SNAPSHOT  avgt    3   736.000 ±    0.008    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space              SNAPSHOT  avgt    3  5499.296 ± 3075.325  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space.norm         SNAPSHOT  avgt    3   737.014 ±  263.768    B/op
SlsVersionBenchmark.safeValueOf:·gc.count                            SNAPSHOT  avgt    3    56.000             counts
SlsVersionBenchmark.safeValueOf:·gc.time                             SNAPSHOT  avgt    3    40.000                 ms
SlsVersionBenchmark.safeValueOf                                            RC  avgt    3   172.288 ±   58.734   ns/op
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate                             RC  avgt    3  5616.204 ± 1917.279  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate.norm                        RC  avgt    3   296.000 ±    0.005    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space                    RC  avgt    3  5664.678 ±   17.326  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space.norm               RC  avgt    3   298.625 ±  101.858    B/op
SlsVersionBenchmark.safeValueOf:·gc.count                                  RC  avgt    3    48.000             counts
SlsVersionBenchmark.safeValueOf:·gc.time                                   RC  avgt    3    47.000                 ms
SlsVersionBenchmark.safeValueOf                                   RC_SNAPSHOT  avgt    3   519.355 ±  247.309   ns/op
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate                    RC_SNAPSHOT  avgt    3  4129.435 ± 1996.364  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate.norm               RC_SNAPSHOT  avgt    3   656.001 ±    0.015    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space           RC_SNAPSHOT  avgt    3  4130.019 ± 3734.514  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space.norm      RC_SNAPSHOT  avgt    3   656.110 ±  520.305    B/op
SlsVersionBenchmark.safeValueOf:·gc.count                         RC_SNAPSHOT  avgt    3    35.000             counts
SlsVersionBenchmark.safeValueOf:·gc.time                          RC_SNAPSHOT  avgt    3    32.000                 ms
SlsVersionBenchmark.safeValueOf                                         DIRTY  avgt    3   405.823 ±   67.392   ns/op
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate                          DIRTY  avgt    3  5283.169 ±  877.502  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.alloc.rate.norm                     DIRTY  avgt    3   656.000 ±    0.011    B/op
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space                 DIRTY  avgt    3  5205.845 ± 3822.913  MB/sec
SlsVersionBenchmark.safeValueOf:·gc.churn.G1_Eden_Space.norm            DIRTY  avgt    3   646.584 ±  579.571    B/op
SlsVersionBenchmark.safeValueOf:·gc.count                               DIRTY  avgt    3    43.000             counts
SlsVersionBenchmark.safeValueOf:·gc.time                                DIRTY  avgt    3    41.000                 ms
```

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Avoid unnecessary substring invocations while parsing sls versions
==COMMIT_MSG==
