### PR TITLE
Fail fast on integer overflow

### DIFF
--- a/changelog/@unreleased/pr-549.v2.yml
+++ b/changelog/@unreleased/pr-549.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: '`OrderableSlsVersion.valueOf` will now refuse to interpret a version
+    string containing a number greater than Integer.MAX_VALUE as a valid orderable
+    version. Previously they would be parsed, but have surprising sorting behaviour.'
+  links:
+  - https://github.com/palantir/sls-version-java/pull/549

--- a/sls-versions/src/main/java/com/palantir/sls/versions/MatchResult.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/MatchResult.java
@@ -16,6 +16,8 @@
 
 package com.palantir.sls.versions;
 
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.regex.Matcher;
 
 interface MatchResult {
@@ -43,7 +45,14 @@ interface MatchResult {
                 throw new NumberFormatException();
             }
 
-            return Integer.parseUnsignedInt(string, groupStart, groupEnd, RADIX);
+            int integer = Integer.parseUnsignedInt(string, groupStart, groupEnd, RADIX);
+            if (integer < 0) {
+                throw new SafeIllegalStateException(
+                        "Can't parse segment as integer as it overflowed",
+                        SafeArg.of("string", string),
+                        SafeArg.of("segment", string.substring(groupStart, groupEnd)));
+            }
+            return integer;
         }
 
         @Override

--- a/sls-versions/src/main/java/com/palantir/sls/versions/MatchResult.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/MatchResult.java
@@ -47,10 +47,8 @@ interface MatchResult {
 
             int integer = Integer.parseUnsignedInt(string, groupStart, groupEnd, RADIX);
             if (integer < 0) {
-                throw new SafeIllegalStateException(
-                        "Can't parse segment as integer as it overflowed",
-                        SafeArg.of("string", string),
-                        SafeArg.of("segment", string.substring(groupStart, groupEnd)));
+                // Extracted to a function to help inlining, as this is probably very uncommon.
+                throw safeIllegalStateException(groupStart, groupEnd);
             }
             return integer;
         }
@@ -58,6 +56,13 @@ interface MatchResult {
         @Override
         public int groupCount() {
             return matcher.groupCount();
+        }
+
+        private SafeIllegalStateException safeIllegalStateException(int groupStart, int groupEnd) {
+            return new SafeIllegalStateException(
+                    "Can't parse segment as integer as it overflowed",
+                    SafeArg.of("string", string),
+                    SafeArg.of("segment", string.substring(groupStart, groupEnd)));
         }
     }
 

--- a/sls-versions/src/main/java/com/palantir/sls/versions/Parsers.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/Parsers.java
@@ -67,7 +67,12 @@ final class Parsers {
             return ok(next, Character.digit(string.codePointAt(startIndex), 10));
         } else {
             try {
-                return ok(next, Integer.parseUnsignedInt(string, startIndex, next, 10));
+                int result = Integer.parseUnsignedInt(string, startIndex, next, 10);
+                if (result < 0) {
+                    // i.e. we overflowed the int
+                    return fail(startIndex);
+                }
+                return ok(next, result);
             } catch (NumberFormatException e) {
                 if (e.getMessage() != null && e.getMessage().endsWith("exceeds range of unsigned int.")) {
                     return fail(startIndex);

--- a/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
@@ -207,6 +207,19 @@ public class OrderableSlsVersionTests {
         assertVersionsEqual("1.0.0-rc3-4-gaaaaa", "1.0.0-rc3-4-gbbbbbb");
     }
 
+    @Test
+    void integer_overflow() {
+        OrderableSlsVersion v0 = OrderableSlsVersion.valueOf("6.12.0");
+        OrderableSlsVersion v1 = OrderableSlsVersion.valueOf("6.12.2201051644");
+        OrderableSlsVersion v2 = OrderableSlsVersion.valueOf("6.12.2201051645");
+
+        assertThat(v0)
+                .describedAs("This breaks if you interpret the 'patch' component as an integer, because it "
+                        + "wraps around and becomes negative")
+                .isLessThan(v1);
+        assertThat(v1).isLessThan(v2);
+    }
+
     private void assertVersionsInOrder(String smaller, String larger) {
         assertThat(OrderableSlsVersion.valueOf(smaller)).isLessThan(OrderableSlsVersion.valueOf(larger));
         assertThat(VersionComparator.INSTANCE.compare(


### PR DESCRIPTION
## Before this PR

In PDS-235827, we've encountered some version strings which are constructed by doing `x.y.yymmddhhmm`. It turns out this was fine last year, but now produces numbers like `1.1.2201051644` which is larger than Integer.MAX_VALUE. The consequence is a bit scary - in the latest version of sls-version-java we'll actually tolerate these, but internally when we store the `.patchVersionNumber(groups.groupAsInt(3));`, the giant integer overflows to becoem a negative number so they SORT WRONG.

## After this PR
==COMMIT_MSG==
`OrderableSlsVersion.valueOf` will now refuse to interpret a version string containing a number greater than Integer.MAX_VALUE as a valid orderable version.
==COMMIT_MSG==

The reason I want to fail hard rather than try to relax this is because the abstract `SlsVersion` class imposes these fun methods which all mention integers, and I have no interest in causing an ABI break just for this.

```java
    public abstract int getMajorVersionNumber();

    public abstract int getMinorVersionNumber();

    public abstract int getPatchVersionNumber();

    public abstract OptionalInt firstSequenceVersionNumber();

    public abstract OptionalInt secondSequenceVersionNumber();
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

