### PR TITLE
Make SlsVersion serializable using Jackson ObjectWriters

### DIFF
--- a/changelog/@unreleased/pr-763.v2.yml
+++ b/changelog/@unreleased/pr-763.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '`SlsVersion` is now serializable.'
+  links:
+  - https://github.com/palantir/sls-version-java/pull/763

--- a/sls-versions/src/main/java/com/palantir/sls/versions/NonOrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/NonOrderableSlsVersion.java
@@ -19,7 +19,6 @@ package com.palantir.sls.versions;
 import static com.palantir.logsafe.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.UnsafeArg;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -62,11 +61,6 @@ public abstract class NonOrderableSlsVersion extends SlsVersion {
     public static boolean check(String coordinate) {
         return safeValueOf(coordinate).isPresent() && !OrderableSlsVersion.check(coordinate);
     }
-
-    @Override
-    @JsonValue
-    @Value.Auxiliary
-    public abstract String getValue();
 
     @Override
     public final String toString() {

--- a/sls-versions/src/main/java/com/palantir/sls/versions/NonOrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/NonOrderableSlsVersion.java
@@ -63,7 +63,11 @@ public abstract class NonOrderableSlsVersion extends SlsVersion {
         return safeValueOf(coordinate).isPresent() && !OrderableSlsVersion.check(coordinate);
     }
 
+    @Override
     @JsonValue
+    @Value.Auxiliary
+    public abstract String getValue();
+
     @Override
     public final String toString() {
         return getValue();

--- a/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
@@ -19,7 +19,6 @@ package com.palantir.sls.versions;
 import static com.palantir.logsafe.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.UnsafeArg;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -84,11 +83,6 @@ public abstract class OrderableSlsVersion extends SlsVersion implements Comparab
     public static boolean check(String coordinate) {
         return safeValueOf(coordinate).isPresent();
     }
-
-    @Override
-    @JsonValue
-    @Value.Auxiliary
-    public abstract String getValue();
 
     @Override
     public final String toString() {

--- a/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
@@ -85,7 +85,11 @@ public abstract class OrderableSlsVersion extends SlsVersion implements Comparab
         return safeValueOf(coordinate).isPresent();
     }
 
+    @Override
     @JsonValue
+    @Value.Auxiliary
+    public abstract String getValue();
+
     @Override
     public final String toString() {
         return getValue();

--- a/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersion.java
@@ -23,6 +23,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.Serializable;
 import java.util.Optional;
 import java.util.OptionalInt;
+import org.immutables.value.Value;
 
 public abstract class SlsVersion implements Serializable {
 
@@ -52,6 +53,7 @@ public abstract class SlsVersion implements Serializable {
 
     /** The full version string. */
     @JsonValue
+    @Value.Auxiliary
     public abstract String getValue();
 
     public abstract int getMajorVersionNumber();

--- a/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersion.java
@@ -17,12 +17,12 @@
 package com.palantir.sls.versions;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.Serializable;
 import java.util.Optional;
 import java.util.OptionalInt;
-import org.immutables.value.Value;
 
 public abstract class SlsVersion implements Serializable {
 
@@ -51,7 +51,7 @@ public abstract class SlsVersion implements Serializable {
     }
 
     /** The full version string. */
-    @Value.Auxiliary
+    @JsonValue
     public abstract String getValue();
 
     public abstract int getMajorVersionNumber();

--- a/sls-versions/src/test/java/com/palantir/sls/versions/NonOrderableVersionTests.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/NonOrderableVersionTests.java
@@ -20,12 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 public class NonOrderableVersionTests {
-
     private static final String[] VALID_NONORDERABLE_VERSIONS =
             new String[] {"1.0.0.dirty", "0.0.1-custom-description-42", "2.0.0-1-gaaaaaa.dirty"};
 
@@ -69,13 +70,19 @@ public class NonOrderableVersionTests {
     @Test
     public void testSerialization() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
+        ObjectReader reader = mapper.readerFor(NonOrderableSlsVersion.class);
+        ObjectWriter writer = mapper.writerFor(NonOrderableSlsVersion.class);
+
         String versionString = "1.2.3-foo";
         NonOrderableSlsVersion version = NonOrderableSlsVersion.valueOf(versionString);
+
         String serialized = mapper.writeValueAsString(version);
         assertThat(serialized).isEqualTo("\"" + versionString + "\"");
+        assertThat(serialized).isEqualTo(writer.writeValueAsString(version));
 
-        NonOrderableSlsVersion deserialized = mapper.readValue(serialized, NonOrderableSlsVersion.class);
+        SlsVersion deserialized = mapper.readValue(serialized, SlsVersion.class);
         assertThat(deserialized).isEqualTo(version);
+        assertThat(deserialized).isEqualTo(reader.readValue(serialized, SlsVersion.class));
     }
 
     @Test

--- a/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -84,13 +86,19 @@ public class OrderableSlsVersionTests {
     @Test
     public void testSerialization() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
+        ObjectReader reader = mapper.readerFor(OrderableSlsVersion.class);
+        ObjectWriter writer = mapper.writerFor(OrderableSlsVersion.class);
+
         for (String versionString : ORDERABLE_VERSIONS_IN_ORDER) {
             OrderableSlsVersion version = OrderableSlsVersion.valueOf(versionString);
+
             String serialized = mapper.writeValueAsString(version);
             assertThat(serialized).isEqualTo("\"" + versionString + "\"");
+            assertThat(serialized).isEqualTo(writer.writeValueAsString(version));
 
-            OrderableSlsVersion deserialized = mapper.readValue(serialized, OrderableSlsVersion.class);
+            SlsVersion deserialized = mapper.readValue(serialized, SlsVersion.class);
             assertThat(deserialized).isEqualTo(version);
+            assertThat(deserialized).isEqualTo(reader.readValue(serialized, SlsVersion.class));
         }
     }
 

--- a/sls-versions/src/test/java/com/palantir/sls/versions/SlsVersionTests.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/SlsVersionTests.java
@@ -19,29 +19,47 @@ package com.palantir.sls.versions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 public class SlsVersionTests {
-    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectReader READER = MAPPER.readerFor(SlsVersion.class);
+    private static final ObjectWriter WRITER = MAPPER.writerFor(SlsVersion.class);
 
     @Test
     public void testCanCreateOrderableVersions() throws IOException {
         String versionString = "1.0.0";
         SlsVersion version = SlsVersion.valueOf(versionString);
+
         assertThat(version).isInstanceOf(OrderableSlsVersion.class);
-        String serialized = mapper.writeValueAsString(version);
-        assertThat(mapper.readValue(serialized, SlsVersion.class)).isEqualTo(version);
+
+        String serialized = MAPPER.writeValueAsString(version);
+        assertThat(serialized).isEqualTo("\"" + versionString + "\"");
+        assertThat(serialized).isEqualTo(WRITER.writeValueAsString(version));
+
+        SlsVersion deserialized = MAPPER.readValue(serialized, SlsVersion.class);
+        assertThat(deserialized).isEqualTo(version);
+        assertThat(deserialized).isEqualTo(READER.readValue(serialized, SlsVersion.class));
     }
 
     @Test
     public void testCanCreateNonOrderableVersions() throws IOException {
         String versionString = "1.0.0-foo";
         SlsVersion version = SlsVersion.valueOf(versionString);
+
         assertThat(version).isInstanceOf(NonOrderableSlsVersion.class);
 
-        String serialized = mapper.writeValueAsString(version);
-        assertThat(mapper.readValue(serialized, SlsVersion.class)).isEqualTo(version);
+        String serialized = MAPPER.writeValueAsString(version);
+        assertThat(serialized).isEqualTo("\"" + versionString + "\"");
+        assertThat(serialized).isEqualTo(WRITER.writeValueAsString(version));
+
+        SlsVersion deserialized = MAPPER.readValue(serialized, SlsVersion.class);
+        assertThat(deserialized).isEqualTo(version);
+        assertThat(deserialized).isEqualTo(READER.readValue(serialized, SlsVersion.class));
     }
 
     @Test


### PR DESCRIPTION
## Before this PR

`SlsVersion` is not serializable. Attempting to serialize an `SlsVersion` using an `ObjectWriter` will use Jackson's default introspection based serialization and produce a value like:

```
{"value":"1.2.3","type":"RELEASE","majorVersionNumber":1,"minorVersionNumber":2,"patchVersionNumber":3}
```

Note that `SlsVersion` does serialize in the expected way when using an `ObjectMapper` because the `ObjectMapper` looks at the Jackson annotations on the subclasses. We have tests for this behavior.

## After this PR

`SlsVersion` is serializable. Attempting to serialize a `SlsVersion` using an `ObjectWriter` behaves in the expected way.

I have updated to the tests to also test serialization/deserialization with an `ObjectWriter`/`ObjectReader`.
