### PR TITLE
Simplify VersionComparators

### DIFF
--- a/changelog/@unreleased/pr-779.v2.yml
+++ b/changelog/@unreleased/pr-779.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Simplify VersionComparators
+
+    Modernize and expand OrderableSlsVersionTests
+  links:
+  - https://github.com/palantir/sls-version-java/pull/779

--- a/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
@@ -16,36 +16,58 @@
 
 package com.palantir.sls.versions;
 
-import static com.palantir.logsafe.Preconditions.checkArgument;
-
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Comparator;
-import java.util.OptionalInt;
 
 /** Compares {@link OrderableSlsVersion}s by "newness", i.e., "1.4.0" is greater/newer/later than "1.2.1", etc.. */
 public enum VersionComparator implements Comparator<OrderableSlsVersion> {
     INSTANCE;
 
+    private static final Comparator<OrderableSlsVersion> majorMinorPatchComparator = Comparator.comparing(
+                    OrderableSlsVersion::getMajorVersionNumber)
+            .thenComparing(OrderableSlsVersion::getMinorVersionNumber)
+            .thenComparing(OrderableSlsVersion::getPatchVersionNumber);
+
+    private static final Comparator<OrderableSlsVersion> typePriority =
+            Comparator.comparingInt(v -> v.getType().getPriority());
+    private static final Comparator<OrderableSlsVersion> firstSequence =
+            Comparator.comparingInt(v -> v.firstSequenceVersionNumber()
+                    .orElseThrow(() -> new SafeIllegalArgumentException(
+                            "Expected to find a first sequence number for version",
+                            SafeArg.of("version", v.getValue()))));
+
+    private static final Comparator<OrderableSlsVersion> secondSequence =
+            // Substitute -1 if not present because snapshots are greater than non-snapshots.
+            Comparator.comparingInt(v -> v.secondSequenceVersionNumber().orElse(-1));
+
+    public static Comparator<OrderableSlsVersion> majorMinorPatch() {
+        return majorMinorPatchComparator;
+    }
+
     @Override
     public int compare(OrderableSlsVersion left, OrderableSlsVersion right) {
-        if (left.getValue().equals(right.getValue())) {
+        @SuppressWarnings("ImmutablesReferenceEquality") // use cheap identity test
+        boolean areSameValue = left == right || left.getValue().equals(right.getValue());
+        if (areSameValue) {
             return 0;
         }
 
-        int mainVersionComparison = compareMainVersion(left, right);
+        int mainVersionComparison = majorMinorPatch().compare(left, right);
         if (mainVersionComparison != 0) {
             return mainVersionComparison;
         }
 
         if ((left.getType() == SlsVersionType.RELEASE) || (right.getType() == SlsVersionType.RELEASE)) {
             // Releases always compare correctly just by type now we know base version matches.
-            return Integer.compare(left.getType().getPriority(), right.getType().getPriority());
+            return typePriority.compare(left, right);
         }
 
         if ((left.getType() == SlsVersionType.RELEASE_SNAPSHOT)
                 && (right.getType() == SlsVersionType.RELEASE_SNAPSHOT)) {
             // If both are snapshots, compare snapshot number.
-            return compareFirstSequenceVersions(left, right);
+
+            return firstSequence.compare(left, right);
         }
 
         if (left.getType() == SlsVersionType.RELEASE_SNAPSHOT) {
@@ -61,50 +83,17 @@ public enum VersionComparator implements Comparator<OrderableSlsVersion> {
         return compareSuffix(left, right);
     }
 
-    private int compareMainVersion(OrderableSlsVersion left, OrderableSlsVersion right) {
-        if (left.getMajorVersionNumber() != right.getMajorVersionNumber()) {
-            return left.getMajorVersionNumber() > right.getMajorVersionNumber() ? 1 : -1;
-        }
-
-        if (left.getMinorVersionNumber() != right.getMinorVersionNumber()) {
-            return left.getMinorVersionNumber() > right.getMinorVersionNumber() ? 1 : -1;
-        }
-
-        if (left.getPatchVersionNumber() != right.getPatchVersionNumber()) {
-            return left.getPatchVersionNumber() > right.getPatchVersionNumber() ? 1 : -1;
-        }
-
-        return 0;
-    }
-
     private int compareSuffix(OrderableSlsVersion left, OrderableSlsVersion right) {
         // We know by this point that both are RCs or RC-snapshots.
         // Compare RC number first.
-        int rcCompare = compareFirstSequenceVersions(left, right);
+
+        int rcCompare = firstSequence.compare(left, right);
         if (rcCompare != 0) {
             return rcCompare;
         }
 
         // RC number is the same, compare snapshot versions.
         // Substitute -1 if not present because snapshots are greater than non-snapshots.
-        OptionalInt leftInt = left.secondSequenceVersionNumber();
-        OptionalInt rightInt = right.secondSequenceVersionNumber();
-        return Integer.compare(leftInt.orElse(-1), rightInt.orElse(-1));
-    }
-
-    private int compareFirstSequenceVersions(OrderableSlsVersion left, OrderableSlsVersion right) {
-        OptionalInt leftInt = left.firstSequenceVersionNumber();
-        OptionalInt rightInt = right.firstSequenceVersionNumber();
-
-        checkArgument(
-                leftInt.isPresent(),
-                "Expected to find a first sequence number for version",
-                SafeArg.of("version", left.getValue()));
-        checkArgument(
-                rightInt.isPresent(),
-                "Expected to find a first sequence number for version",
-                SafeArg.of("version", right.getValue()));
-
-        return Integer.compare(leftInt.getAsInt(), rightInt.getAsInt());
+        return secondSequence.compare(left, right);
     }
 }


### PR DESCRIPTION
## Before this PR
`VersionComparators` included a lot of hand rolled comparators, where we could simplify and reuse `Comparator.comparing` & `Comparator.thenComparing`.

These comparators end up in hot paths when sorting by `OrderableSlsVersion`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Simplify VersionComparators

Modernize and expand OrderableSlsVersionTests
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

