### PR TITLE
Improve `OrderableSlsVersion` model and simplify comparison logic

### DIFF
--- a/sls-versions/src/jmh/java/com/palantir/sls/versions/SlsVersionBenchmark.java
+++ b/sls-versions/src/jmh/java/com/palantir/sls/versions/SlsVersionBenchmark.java
@@ -49,8 +49,10 @@ public class SlsVersionBenchmark {
         RELEASE("0.16.0"),
         SNAPSHOT("0.16.0-8-g116b425"),
         RC("0.16.0-rc1"),
-        RC_SNAPSHOT("0.16.0-rc1-8-g116b425.dirty"),
-        DIRTY("0.16.0-8-g116b425.dirty");
+        RC_SNAPSHOT("0.16.0-rc1-8-g116b425"),
+        DIRTY("0.16.0-8-g116b425.dirty"),
+        DIRTY_RC("0.16.0-rc1-8-g116b425.dirty"),
+        ;
 
         private final String string;
 

--- a/sls-versions/src/main/java/com/palantir/sls/versions/CompactVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/CompactVersion.java
@@ -30,7 +30,7 @@ import java.util.OptionalInt;
  *
  * <p>Bits are allocated as follows, from lowest bits to highest: <code>
  * LSB SafeLong:
- * 20 bits: distance from release
+ * 20 bits: snapshot number
  *  2 bits: priority1 (1 = RELEASE_CANDIDATE_SNAPSHOT, 0 = else; 2 and 3 are unused values)
  * 20 bits: RC number
  *  2 bits: priority2 (2 = RELEASE_SNAPSHOT, 1 = RELEASE, 0 = RELEASE_CANDIDATE; 3 is an unused value)
@@ -71,8 +71,8 @@ public final class CompactVersion implements Comparable<CompactVersion> {
     public static CompactVersion from(OrderableSlsVersion version) {
         long patch = encode20b(version.getPatchVersionNumber(), "patch");
 
-        int rcNumber = version.rcVersionNumber().orElse(0);
-        int distanceFromVersion = version.snapshotVersionNumber().orElse(0);
+        int rcNumber = version.rcNumber().orElse(0);
+        int distanceFromVersion = version.snapshotNumber().orElse(0);
 
         long lsb = encode20b(distanceFromVersion, "distanceFromVersion")
                 + (encodePriority1(version.getType()) << 20)
@@ -125,16 +125,16 @@ public final class CompactVersion implements Comparable<CompactVersion> {
         SlsVersionType type = typeFromPriority(priority1, priority2);
 
         int rcNumber = (int) (lsb >> 22) & MASK_20_BITS;
-        int distanceFromVersion = (int) lsb & MASK_20_BITS;
+        int snapshotNumber = (int) lsb & MASK_20_BITS;
 
-        OptionalInt firstSeq = OptionalInt.empty();
-        OptionalInt secondSeq = OptionalInt.empty();
+        OptionalInt rcNum = OptionalInt.empty();
+        OptionalInt snapshotNum = OptionalInt.empty();
         switch (type) {
-            case RELEASE_CANDIDATE -> firstSeq = OptionalInt.of(rcNumber);
-            case RELEASE_SNAPSHOT -> firstSeq = OptionalInt.of(distanceFromVersion);
+            case RELEASE_CANDIDATE -> rcNum = OptionalInt.of(rcNumber);
+            case RELEASE_SNAPSHOT -> snapshotNum = OptionalInt.of(snapshotNumber);
             case RELEASE_CANDIDATE_SNAPSHOT -> {
-                firstSeq = OptionalInt.of(rcNumber);
-                secondSeq = OptionalInt.of(distanceFromVersion);
+                rcNum = OptionalInt.of(rcNumber);
+                snapshotNum = OptionalInt.of(snapshotNumber);
             }
             case RELEASE, NON_ORDERABLE -> {}
         }
@@ -143,15 +143,10 @@ public final class CompactVersion implements Comparable<CompactVersion> {
                 .minorVersionNumber(minorVersionNumber)
                 .patchVersionNumber(patchVersionNumber)
                 .type(type)
-                .firstSequenceVersionNumber(firstSeq)
-                .secondSequenceVersionNumber(secondSeq)
+                .rcNumber(rcNum)
+                .snapshotNumber(snapshotNum)
                 .value(generateVersionString(
-                        majorVersionNumber,
-                        minorVersionNumber,
-                        patchVersionNumber,
-                        type,
-                        rcNumber,
-                        distanceFromVersion))
+                        majorVersionNumber, minorVersionNumber, patchVersionNumber, type, rcNumber, snapshotNumber))
                 .build();
     }
 

--- a/sls-versions/src/main/java/com/palantir/sls/versions/CompactVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/CompactVersion.java
@@ -71,14 +71,8 @@ public final class CompactVersion implements Comparable<CompactVersion> {
     public static CompactVersion from(OrderableSlsVersion version) {
         long patch = encode20b(version.getPatchVersionNumber(), "patch");
 
-        int rcNumber = version.firstSequenceVersionNumber().orElse(0);
-        int distanceFromVersion = version.secondSequenceVersionNumber().orElse(0);
-        if (version.getType().equals(SlsVersionType.RELEASE_SNAPSHOT)) {
-            // in this version format (1.0.0-10-gaaaaaa), the first sequence number represents the distance
-            // from the version rather than the implicit RC number
-            rcNumber = 0;
-            distanceFromVersion = version.firstSequenceVersionNumber().orElse(0);
-        }
+        int rcNumber = version.rcVersionNumber().orElse(0);
+        int distanceFromVersion = version.snapshotVersionNumber().orElse(0);
 
         long lsb = encode20b(distanceFromVersion, "distanceFromVersion")
                 + (encodePriority1(version.getType()) << 20)

--- a/sls-versions/src/main/java/com/palantir/sls/versions/CompactVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/CompactVersion.java
@@ -72,9 +72,9 @@ public final class CompactVersion implements Comparable<CompactVersion> {
         long patch = encode20b(version.getPatchVersionNumber(), "patch");
 
         int rcNumber = version.rcNumber().orElse(0);
-        int distanceFromVersion = version.snapshotNumber().orElse(0);
+        int snapshotNumber = version.snapshotNumber().orElse(0);
 
-        long lsb = encode20b(distanceFromVersion, "distanceFromVersion")
+        long lsb = encode20b(snapshotNumber, "snapshotNumber")
                 + (encodePriority1(version.getType()) << 20)
                 + (encode20b(rcNumber, "rcNumber") << 22)
                 + (encodePriority2(version.getType()) << 42)
@@ -146,7 +146,7 @@ public final class CompactVersion implements Comparable<CompactVersion> {
                 .rcNumber(rcNum)
                 .snapshotNumber(snapshotNum)
                 .value(generateVersionString(
-                        majorVersionNumber, minorVersionNumber, patchVersionNumber, type, rcNumber, snapshotNumber))
+                        majorVersionNumber, minorVersionNumber, patchVersionNumber, rcNum, snapshotNum))
                 .build();
     }
 
@@ -163,14 +163,14 @@ public final class CompactVersion implements Comparable<CompactVersion> {
     }
 
     private static String generateVersionString(
-            int major, int minor, int patch, SlsVersionType type, int rcNumber, int distanceFromVersion) {
+            int major, int minor, int patch, OptionalInt rcNumber, OptionalInt snapshotNumber) {
         StringBuilder sb = new StringBuilder();
         sb.append(major).append(".").append(minor).append(".").append(patch);
-        if (type.isReleaseCandidate()) {
-            sb.append("-rc").append(rcNumber);
+        if (rcNumber.isPresent()) {
+            sb.append("-rc").append(rcNumber.getAsInt());
         }
-        if (type.isSnapshot()) {
-            sb.append("-").append(distanceFromVersion).append("-gaaaaaa");
+        if (snapshotNumber.isPresent()) {
+            sb.append("-").append(snapshotNumber.getAsInt()).append("-gaaaaaa");
         }
         return sb.toString();
     }

--- a/sls-versions/src/main/java/com/palantir/sls/versions/NonOrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/NonOrderableSlsVersion.java
@@ -21,6 +21,7 @@ import static com.palantir.logsafe.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.palantir.logsafe.UnsafeArg;
 import java.util.Optional;
+import java.util.OptionalInt;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -50,7 +51,6 @@ public abstract class NonOrderableSlsVersion extends SlsVersion {
                 .majorVersionNumber(groups.groupAsInt(1))
                 .minorVersionNumber(groups.groupAsInt(2))
                 .patchVersionNumber(groups.groupAsInt(3))
-                .type(SlsVersionType.NON_ORDERABLE)
                 .build());
     }
 
@@ -60,6 +60,21 @@ public abstract class NonOrderableSlsVersion extends SlsVersion {
      */
     public static boolean check(String coordinate) {
         return safeValueOf(coordinate).isPresent() && !OrderableSlsVersion.check(coordinate);
+    }
+
+    @Override
+    public final OptionalInt rcNumber() {
+        return OptionalInt.empty();
+    }
+
+    @Override
+    public final OptionalInt snapshotNumber() {
+        return OptionalInt.empty();
+    }
+
+    @Override
+    public final SlsVersionType getType() {
+        return SlsVersionType.NON_ORDERABLE;
     }
 
     @Override

--- a/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
@@ -21,7 +21,6 @@ import static com.palantir.logsafe.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.palantir.logsafe.UnsafeArg;
 import java.util.Optional;
-import java.util.OptionalInt;
 import org.immutables.value.Value;
 
 /**
@@ -31,43 +30,6 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutablesStyle
 public abstract class OrderableSlsVersion extends SlsVersion implements Comparable<OrderableSlsVersion> {
-
-    private static final SlsVersionType[] ORDERED_VERSION_TYPES = {
-        SlsVersionType.RELEASE,
-        SlsVersionType.RELEASE_CANDIDATE,
-        SlsVersionType.RELEASE_CANDIDATE_SNAPSHOT,
-        SlsVersionType.RELEASE_SNAPSHOT
-    };
-
-    /**
-     * The release candidate version number, if this version is a release candidate or release candidate snapshot.
-     */
-    @Value.Derived
-    OptionalInt rcVersionNumber() {
-        if (getType() == SlsVersionType.RELEASE_CANDIDATE || getType() == SlsVersionType.RELEASE_CANDIDATE_SNAPSHOT) {
-            // If the version is a release candidate (or RC snapshot),
-            //   the first sequence number is always the RC version number.
-            return firstSequenceVersionNumber();
-        }
-        return OptionalInt.empty();
-    }
-
-    /**
-     * The snapshot version number, if this version is a release snapshot or release candidate snapshot.
-     */
-    @Value.Derived
-    OptionalInt snapshotVersionNumber() {
-        if (getType() == SlsVersionType.RELEASE_SNAPSHOT) {
-            // If the version is a release snapshot, the first sequence number is always the snapshot version number
-            //   since there isn't an RC version number.
-            return firstSequenceVersionNumber();
-        } else if (getType() == SlsVersionType.RELEASE_CANDIDATE_SNAPSHOT) {
-            // For RC snapshots, the first sequence number is the RC version number,
-            //   and the second sequence number is the snapshot version number.
-            return secondSequenceVersionNumber();
-        }
-        return OptionalInt.empty();
-    }
 
     @JsonCreator
     public static OrderableSlsVersion valueOf(String value) {
@@ -82,32 +44,55 @@ public abstract class OrderableSlsVersion extends SlsVersion implements Comparab
             return Optional.empty();
         }
 
-        for (SlsVersionType type : ORDERED_VERSION_TYPES) {
-            MatchResult groups = type.getParser().tryParse(value);
-            if (groups != null) {
-                return Optional.of(construct(type, value, groups));
-            }
+        MatchResult groups = SlsVersionType.RELEASE.getParser().tryParse(value);
+        if (groups != null) {
+            return Optional.of(new Builder()
+                    .value(value)
+                    .type(SlsVersionType.RELEASE)
+                    .majorVersionNumber(groups.groupAsInt(1))
+                    .minorVersionNumber(groups.groupAsInt(2))
+                    .patchVersionNumber(groups.groupAsInt(3))
+                    .build());
+        }
+
+        groups = SlsVersionType.RELEASE_CANDIDATE.getParser().tryParse(value);
+        if (groups != null) {
+            return Optional.of(new Builder()
+                    .value(value)
+                    .type(SlsVersionType.RELEASE_CANDIDATE)
+                    .majorVersionNumber(groups.groupAsInt(1))
+                    .minorVersionNumber(groups.groupAsInt(2))
+                    .patchVersionNumber(groups.groupAsInt(3))
+                    .rcNumber(groups.groupAsInt(4))
+                    .build());
+        }
+
+        groups = SlsVersionType.RELEASE_CANDIDATE_SNAPSHOT.getParser().tryParse(value);
+        if (groups != null) {
+            return Optional.of(new Builder()
+                    .value(value)
+                    .type(SlsVersionType.RELEASE_CANDIDATE_SNAPSHOT)
+                    .majorVersionNumber(groups.groupAsInt(1))
+                    .minorVersionNumber(groups.groupAsInt(2))
+                    .patchVersionNumber(groups.groupAsInt(3))
+                    .rcNumber(groups.groupAsInt(4))
+                    .snapshotNumber(groups.groupAsInt(5))
+                    .build());
+        }
+
+        groups = SlsVersionType.RELEASE_SNAPSHOT.getParser().tryParse(value);
+        if (groups != null) {
+            return Optional.of(new Builder()
+                    .value(value)
+                    .type(SlsVersionType.RELEASE_SNAPSHOT)
+                    .majorVersionNumber(groups.groupAsInt(1))
+                    .minorVersionNumber(groups.groupAsInt(2))
+                    .patchVersionNumber(groups.groupAsInt(3))
+                    .snapshotNumber(groups.groupAsInt(4))
+                    .build());
         }
 
         return Optional.empty();
-    }
-
-    private static OrderableSlsVersion construct(SlsVersionType type, String value, MatchResult groups) {
-        OrderableSlsVersion.Builder orderableSlsVersion = new Builder()
-                .type(type)
-                .value(value)
-                .majorVersionNumber(groups.groupAsInt(1))
-                .minorVersionNumber(groups.groupAsInt(2))
-                .patchVersionNumber(groups.groupAsInt(3));
-
-        if (groups.groupCount() >= 4) {
-            orderableSlsVersion.firstSequenceVersionNumber(groups.groupAsInt(4));
-        }
-        if (groups.groupCount() >= 5) {
-            orderableSlsVersion.secondSequenceVersionNumber(groups.groupAsInt(5));
-        }
-
-        return orderableSlsVersion.build();
     }
 
     /** Returns true iff the given coordinate has a version which can be parsed into a valid orderable SLS version. */

--- a/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
@@ -21,6 +21,7 @@ import static com.palantir.logsafe.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.palantir.logsafe.UnsafeArg;
 import java.util.Optional;
+import java.util.OptionalInt;
 import org.immutables.value.Value;
 
 /**
@@ -37,6 +38,36 @@ public abstract class OrderableSlsVersion extends SlsVersion implements Comparab
         SlsVersionType.RELEASE_CANDIDATE_SNAPSHOT,
         SlsVersionType.RELEASE_SNAPSHOT
     };
+
+    /**
+     * The release candidate version number, if this version is a release candidate or release candidate snapshot.
+     */
+    @Value.Derived
+    OptionalInt rcVersionNumber() {
+        if (getType() == SlsVersionType.RELEASE_CANDIDATE || getType() == SlsVersionType.RELEASE_CANDIDATE_SNAPSHOT) {
+            // If the version is a release candidate (or RC snapshot),
+            //   the first sequence number is always the RC version number.
+            return firstSequenceVersionNumber();
+        }
+        return OptionalInt.empty();
+    }
+
+    /**
+     * The snapshot version number, if this version is a release snapshot or release candidate snapshot.
+     */
+    @Value.Derived
+    OptionalInt snapshotVersionNumber() {
+        if (getType() == SlsVersionType.RELEASE_SNAPSHOT) {
+            // If the version is a release snapshot, the first sequence number is always the snapshot version number
+            //   since there isn't an RC version number.
+            return firstSequenceVersionNumber();
+        } else if (getType() == SlsVersionType.RELEASE_CANDIDATE_SNAPSHOT) {
+            // For RC snapshots, the first sequence number is the RC version number,
+            //   and the second sequence number is the snapshot version number.
+            return secondSequenceVersionNumber();
+        }
+        return OptionalInt.empty();
+    }
 
     @JsonCreator
     public static OrderableSlsVersion valueOf(String value) {

--- a/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersion.java
@@ -63,20 +63,42 @@ public abstract class SlsVersion implements Serializable {
     public abstract int getPatchVersionNumber();
 
     /**
-     * The first version number after major, minor, and patch. Typically either RC or snapshot version number.
-     * @deprecated Use {@link OrderableSlsVersion#rcVersionNumber()} or
-     *   {@link OrderableSlsVersion#snapshotVersionNumber()} instead.
+     * The release candidate version number, if this version is a release candidate or release candidate snapshot.
      */
-    @Deprecated
-    public abstract OptionalInt firstSequenceVersionNumber();
+    public abstract OptionalInt rcNumber();
 
     /**
-     * The second version number after major, minor, and patch. Typically snapshot version number for RC snapshots.
-     * @deprecated Use {@link OrderableSlsVersion#rcVersionNumber()} or
-     *   {@link OrderableSlsVersion#snapshotVersionNumber()} instead.
+     * The snapshot version number, if this version is a release snapshot or release candidate snapshot.
      */
-    @Deprecated
-    public abstract OptionalInt secondSequenceVersionNumber();
+    public abstract OptionalInt snapshotNumber();
+
+    /**
+     * The first version number after major, minor, and patch.
+     * The release candidate number, if this version is a release candidate or a release candidate snapshot,
+     *   and the snapshot number, if this version is a release snapshot.
+     *
+     * Prefer {@link SlsVersion#rcNumber()} or {@link SlsVersion#snapshotNumber()} instead, as these will be deprecated.
+     */
+    public OptionalInt firstSequenceVersionNumber() {
+        return switch (getType()) {
+            case RELEASE_CANDIDATE, RELEASE_CANDIDATE_SNAPSHOT -> rcNumber();
+            case RELEASE_SNAPSHOT -> snapshotNumber();
+            case RELEASE, NON_ORDERABLE -> OptionalInt.empty();
+        };
+    }
+
+    /**
+     * The second version number after major, minor, and patch.
+     * The snapshot number, if this version is a release candidate snapshot
+     *
+     * Prefer {@link SlsVersion#rcNumber()} or {@link SlsVersion#snapshotNumber()} instead, as these will be deprecated.
+     */
+    public OptionalInt secondSequenceVersionNumber() {
+        return switch (getType()) {
+            case RELEASE_CANDIDATE_SNAPSHOT -> snapshotNumber();
+            case RELEASE, RELEASE_CANDIDATE, RELEASE_SNAPSHOT, NON_ORDERABLE -> OptionalInt.empty();
+        };
+    }
 
     public abstract SlsVersionType getType();
 }

--- a/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersion.java
@@ -62,8 +62,20 @@ public abstract class SlsVersion implements Serializable {
 
     public abstract int getPatchVersionNumber();
 
+    /**
+     * The first version number after major, minor, and patch. Typically either RC or snapshot version number.
+     * @deprecated Use {@link OrderableSlsVersion#rcVersionNumber()} or
+     *   {@link OrderableSlsVersion#snapshotVersionNumber()} instead.
+     */
+    @Deprecated
     public abstract OptionalInt firstSequenceVersionNumber();
 
+    /**
+     * The second version number after major, minor, and patch. Typically snapshot version number for RC snapshots.
+     * @deprecated Use {@link OrderableSlsVersion#rcVersionNumber()} or
+     *   {@link OrderableSlsVersion#snapshotVersionNumber()} instead.
+     */
+    @Deprecated
     public abstract OptionalInt secondSequenceVersionNumber();
 
     public abstract SlsVersionType getType();

--- a/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersionType.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersionType.java
@@ -45,6 +45,13 @@ public enum SlsVersionType {
         this.priority = priority;
     }
 
+    /**
+     * The priority was used to have a predetermined order of version types, to ease comparison,
+     *   but suffered problems due to RELEASE_CANDIDATE_SNAPSHOT and RELEASE_CANDIDATE versions not being systematically
+     *   ordered (e.g. 1.2.3-rc1 < 1.2.3-rc1-1-gabc < 1.2.3-rc2 < 1.2.3-rc2-1-gdef).
+     * @deprecated This field is deprecated and will be removed in a future release.
+     */
+    @Deprecated(forRemoval = true)
     public int getPriority() {
         return this.priority;
     }

--- a/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
@@ -45,20 +45,22 @@ public enum VersionComparator implements Comparator<OrderableSlsVersion> {
             return result;
         }
 
-        // If RC version is not present, treat it as meaning positive infinite,
-        //   as all releases/release snapshots are considered newer than any RC.
+        // If release candidate version is not present, treat it the maximum value.
+        // All release and release snapshots versions are newer than any release candidate
+        //   or release candidate snapshot version.
         result = Integer.compare(
-                version1.rcVersionNumber().orElse(Integer.MAX_VALUE),
-                version2.rcVersionNumber().orElse(Integer.MAX_VALUE));
+                version1.rcNumber().orElse(Integer.MAX_VALUE),
+                version2.rcNumber().orElse(Integer.MAX_VALUE));
         if (result != 0) {
             return result;
         }
 
-        // If snapshot version is not present, treat it as meaning negative infinite,
-        //   as all snapshots are considered newer than the release/RC they're tied to.
+        // If snapshot version is not present, treat it as the minimum value.
+        // All release snapshots and release candidate snapshots versions are newer than
+        //   their corresponding release and release candidate versions, respectively.
         result = Integer.compare(
-                version1.snapshotVersionNumber().orElse(Integer.MIN_VALUE),
-                version2.snapshotVersionNumber().orElse(Integer.MIN_VALUE));
+                version1.snapshotNumber().orElse(Integer.MIN_VALUE),
+                version2.snapshotNumber().orElse(Integer.MIN_VALUE));
         if (result != 0) {
             return result;
         }

--- a/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
@@ -25,6 +25,7 @@ public enum VersionComparator implements Comparator<OrderableSlsVersion> {
     @Override
     @SuppressWarnings("ImmutablesReferenceEquality")
     public int compare(OrderableSlsVersion version1, OrderableSlsVersion version2) {
+        // Short-circuit if the same instance is passed in
         if (version1 == version2) {
             return 0;
         }
@@ -44,6 +45,8 @@ public enum VersionComparator implements Comparator<OrderableSlsVersion> {
             return result;
         }
 
+        // If RC version is not present, treat it as meaning positive infinite,
+        //   as all releases/release snapshots are considered newer than any RC.
         result = Integer.compare(
                 version1.rcVersionNumber().orElse(Integer.MAX_VALUE),
                 version2.rcVersionNumber().orElse(Integer.MAX_VALUE));
@@ -51,6 +54,8 @@ public enum VersionComparator implements Comparator<OrderableSlsVersion> {
             return result;
         }
 
+        // If snapshot version is not present, treat it as meaning negative infinite,
+        //   as all snapshots are considered newer than the release/RC they're tied to.
         result = Integer.compare(
                 version1.snapshotVersionNumber().orElse(Integer.MIN_VALUE),
                 version2.snapshotVersionNumber().orElse(Integer.MIN_VALUE));

--- a/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
@@ -16,95 +16,48 @@
 
 package com.palantir.sls.versions;
 
-import static com.palantir.logsafe.Preconditions.checkArgument;
-
-import com.palantir.logsafe.SafeArg;
 import java.util.Comparator;
-import java.util.OptionalInt;
 
 /** Compares {@link OrderableSlsVersion}s by "newness", i.e., "1.4.0" is greater/newer/later than "1.2.1", etc.. */
 public enum VersionComparator implements Comparator<OrderableSlsVersion> {
     INSTANCE;
 
     @Override
-    public int compare(OrderableSlsVersion left, OrderableSlsVersion right) {
-        if (left.getValue().equals(right.getValue())) {
+    @SuppressWarnings("ImmutablesReferenceEquality")
+    public int compare(OrderableSlsVersion version1, OrderableSlsVersion version2) {
+        if (version1 == version2) {
             return 0;
         }
 
-        int mainVersionComparison = compareMainVersion(left, right);
-        if (mainVersionComparison != 0) {
-            return mainVersionComparison;
+        int result = Integer.compare(version1.getMajorVersionNumber(), version2.getMajorVersionNumber());
+        if (result != 0) {
+            return result;
         }
 
-        if ((left.getType() == SlsVersionType.RELEASE) || (right.getType() == SlsVersionType.RELEASE)) {
-            // Releases always compare correctly just by type now we know base version matches.
-            return Integer.compare(left.getType().getPriority(), right.getType().getPriority());
+        result = Integer.compare(version1.getMinorVersionNumber(), version2.getMinorVersionNumber());
+        if (result != 0) {
+            return result;
         }
 
-        if ((left.getType() == SlsVersionType.RELEASE_SNAPSHOT)
-                && (right.getType() == SlsVersionType.RELEASE_SNAPSHOT)) {
-            // If both are snapshots, compare snapshot number.
-            return compareFirstSequenceVersions(left, right);
+        result = Integer.compare(version1.getPatchVersionNumber(), version2.getPatchVersionNumber());
+        if (result != 0) {
+            return result;
         }
 
-        if (left.getType() == SlsVersionType.RELEASE_SNAPSHOT) {
-            // Snapshot is larger.
-            return 1;
+        result = Integer.compare(
+                version1.rcVersionNumber().orElse(Integer.MAX_VALUE),
+                version2.rcVersionNumber().orElse(Integer.MAX_VALUE));
+        if (result != 0) {
+            return result;
         }
 
-        if (right.getType() == SlsVersionType.RELEASE_SNAPSHOT) {
-            // Snapshot is larger.
-            return -1;
-        }
-
-        return compareSuffix(left, right);
-    }
-
-    private int compareMainVersion(OrderableSlsVersion left, OrderableSlsVersion right) {
-        if (left.getMajorVersionNumber() != right.getMajorVersionNumber()) {
-            return left.getMajorVersionNumber() > right.getMajorVersionNumber() ? 1 : -1;
-        }
-
-        if (left.getMinorVersionNumber() != right.getMinorVersionNumber()) {
-            return left.getMinorVersionNumber() > right.getMinorVersionNumber() ? 1 : -1;
-        }
-
-        if (left.getPatchVersionNumber() != right.getPatchVersionNumber()) {
-            return left.getPatchVersionNumber() > right.getPatchVersionNumber() ? 1 : -1;
+        result = Integer.compare(
+                version1.snapshotVersionNumber().orElse(Integer.MIN_VALUE),
+                version2.snapshotVersionNumber().orElse(Integer.MIN_VALUE));
+        if (result != 0) {
+            return result;
         }
 
         return 0;
-    }
-
-    private int compareSuffix(OrderableSlsVersion left, OrderableSlsVersion right) {
-        // We know by this point that both are RCs or RC-snapshots.
-        // Compare RC number first.
-        int rcCompare = compareFirstSequenceVersions(left, right);
-        if (rcCompare != 0) {
-            return rcCompare;
-        }
-
-        // RC number is the same, compare snapshot versions.
-        // Substitute -1 if not present because snapshots are greater than non-snapshots.
-        OptionalInt leftInt = left.secondSequenceVersionNumber();
-        OptionalInt rightInt = right.secondSequenceVersionNumber();
-        return Integer.compare(leftInt.orElse(-1), rightInt.orElse(-1));
-    }
-
-    private int compareFirstSequenceVersions(OrderableSlsVersion left, OrderableSlsVersion right) {
-        OptionalInt leftInt = left.firstSequenceVersionNumber();
-        OptionalInt rightInt = right.firstSequenceVersionNumber();
-
-        checkArgument(
-                leftInt.isPresent(),
-                "Expected to find a first sequence number for version",
-                SafeArg.of("version", left.getValue()));
-        checkArgument(
-                rightInt.isPresent(),
-                "Expected to find a first sequence number for version",
-                SafeArg.of("version", right.getValue()));
-
-        return Integer.compare(leftInt.getAsInt(), rightInt.getAsInt());
     }
 }

--- a/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
@@ -114,7 +114,7 @@ public class OrderableSlsVersionTests {
                         version("1.2.3-rc2-1-gabc", 1, 2, 3, SlsVersionType.RELEASE_CANDIDATE_SNAPSHOT, 2, 1));
         assertThat(OrderableSlsVersion.valueOf("1.2.3-4-gabc"))
                 .isEqualToComparingFieldByField(
-                        version("1.2.3-4-gabc", 1, 2, 3, SlsVersionType.RELEASE_SNAPSHOT, 4, null));
+                        version("1.2.3-4-gabc", 1, 2, 3, SlsVersionType.RELEASE_SNAPSHOT, null, 4));
     }
 
     @Test
@@ -273,17 +273,16 @@ public class OrderableSlsVersionTests {
             int minor,
             int patch,
             SlsVersionType type,
-            Integer firstSequence,
-            Integer secondSequence) {
+            Integer rcNumber,
+            Integer snapshotNumber) {
         return new OrderableSlsVersion.Builder()
                 .value(version)
                 .majorVersionNumber(major)
                 .minorVersionNumber(minor)
                 .patchVersionNumber(patch)
                 .type(type)
-                .firstSequenceVersionNumber(firstSequence == null ? OptionalInt.empty() : OptionalInt.of(firstSequence))
-                .secondSequenceVersionNumber(
-                        secondSequence == null ? OptionalInt.empty() : OptionalInt.of(secondSequence))
+                .rcNumber(rcNumber == null ? OptionalInt.empty() : OptionalInt.of(rcNumber))
+                .snapshotNumber(snapshotNumber == null ? OptionalInt.empty() : OptionalInt.of(snapshotNumber))
                 .build();
     }
 }


### PR DESCRIPTION
## Before this PR
See https://github.com/palantir/sls-version-java/pull/1179 and discussion starting from https://github.com/palantir/sls-version-java/pull/1179#pullrequestreview-3140660469

The [comparison logic in `VersionComparator` is fairly convoluted](https://github.com/palantir/sls-version-java/blob/1799afe53d6d6febbfcd630e53a9272ecf43ecba/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java#L30-L109), because we tried to order version types using priorities. But `RELEASE_CANDIDATE` is not universally ordered with respect to `RELEASE_CANDIDATE_SNAPSHOT` (for instance, `1.2.3-rc1 < 1.2.3-rc1-1-gabc < 1.2.3-rc2`). This means you can't simply define a priority on version types that you can leverage to order the versions of different types.

Instead, we can simply model `OrderableSlsVersion` as having 5 components:
- The already-existing major, minor and patch version numbers
- RC version number
  - When absent, it is considering as positive infinite for comparison purposes
- Snapshot version number
  - When absent, it is considering as _negative_ infinite for comparison purposes

This leads to a simple lexicographic comparison of the different numbers, in order:
| Version | Parsed |
|-|-|
| `1.0.0-rc1` | `[1, 0, 0, 1, -infinite]` |
| `1.0.0-rc1-1-gabcedf` | `[1, 0, 0, 1, 1]` |
| `1.0.0-rc1-2-gabcedf` | `[1, 0, 0, 1, 2]` |
| `1.0.0-rc2` | `[1, 0, 0, 2, -infinite]` |
| `1.0.0` | `[1, 0, 0, +infinite, -infinite]` |
| `1.0.0-1-gabcedf` | `[1, 0, 0, +infinite, 1]` |
| `1.0.0-2-gabcedf` | `[1, 0, 0, +infinite, 2]` |
| `1.0.1-rc1` | `[1, 0, 1, 1, -infinite]` |
| `1.0.1` | `[1, 0, 1, +infinite, -infinite]` |
| `1.1.0` | `[1, 1, 0, +infinite, -infinite]` |
| `2.0.0` | `[2, 0, 0, +infinite, -infinite]` |

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Improve OrderableSlsVersion model and simplify comparison logic
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

