### PR TITLE
[DO NOT MERGE] Compare approaches to simplify version comparison

### DIFF
--- a/sls-versions/src/jmh/java/com/palantir/sls/versions/SlsVersionComparisonBenchmark.java
+++ b/sls-versions/src/jmh/java/com/palantir/sls/versions/SlsVersionComparisonBenchmark.java
@@ -16,7 +16,6 @@
 
 package com.palantir.sls.versions;
 
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -42,36 +41,45 @@ import org.openjdk.jmh.runner.options.TimeValue;
 @Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 @Threads(4)
-@SuppressWarnings({"checkstyle:hideutilityclassconstructor", "VisibilityModifier", "DesignForExtension"})
-public class SlsVersionBenchmark {
+@SuppressWarnings({
+    "checkstyle:hideutilityclassconstructor",
+    "VisibilityModifier",
+    "DesignForExtension",
+    "ImmutableEnumChecker"
+})
+public class SlsVersionComparisonBenchmark {
 
-    public enum VersionString {
+    public enum Version {
         RELEASE("0.16.0"),
         SNAPSHOT("0.16.0-8-g116b425"),
         RC("0.16.0-rc1"),
         RC_SNAPSHOT("0.16.0-rc1-8-g116b425"),
-        DIRTY("0.16.0-8-g116b425.dirty"),
-        DIRTY_RC("0.16.0-rc1-8-g116b425.dirty"),
         ;
 
-        private final String string;
+        private final OrderableSlsVersion version;
+        // Used to avoid comparing the object's identities when comparing the same version
+        private final OrderableSlsVersion version2;
 
-        VersionString(String string) {
-            this.string = string;
+        Version(String string) {
+            this.version = OrderableSlsVersion.valueOf(string);
+            this.version2 = OrderableSlsVersion.valueOf(string);
         }
     }
 
     @Param
-    VersionString versionString;
+    Version version1;
+
+    @Param
+    Version version2;
 
     @Benchmark
-    public Optional<OrderableSlsVersion> safeValueOf() {
-        return OrderableSlsVersion.safeValueOf(versionString.string);
+    public int compare() {
+        return version1.version.compareTo(version2.version2);
     }
 
     public static void main(String[] _args) throws Exception {
         Options opt = new OptionsBuilder()
-                .include(SlsVersionBenchmark.class.getSimpleName())
+                .include(SlsVersionComparisonBenchmark.class.getSimpleName())
                 .addProfiler(GCProfiler.class)
                 .forks(1)
                 .threads(4)

--- a/sls-versions/src/main/java/com/palantir/sls/versions/CompactVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/CompactVersion.java
@@ -20,7 +20,6 @@ import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
-import java.util.OptionalInt;
 
 /**
  * Stores a compact representation of {@link OrderableSlsVersion} that is lexicographically ordered when rendered as a
@@ -133,14 +132,14 @@ public final class CompactVersion implements Comparable<CompactVersion> {
         int rcNumber = (int) (lsb >> 22) & MASK_20_BITS;
         int distanceFromVersion = (int) lsb & MASK_20_BITS;
 
-        OptionalInt firstSeq = OptionalInt.empty();
-        OptionalInt secondSeq = OptionalInt.empty();
+        Integer firstSeq = null;
+        Integer secondSeq = null;
         switch (type) {
-            case RELEASE_CANDIDATE -> firstSeq = OptionalInt.of(rcNumber);
-            case RELEASE_SNAPSHOT -> firstSeq = OptionalInt.of(distanceFromVersion);
+            case RELEASE_CANDIDATE -> firstSeq = rcNumber;
+            case RELEASE_SNAPSHOT -> firstSeq = distanceFromVersion;
             case RELEASE_CANDIDATE_SNAPSHOT -> {
-                firstSeq = OptionalInt.of(rcNumber);
-                secondSeq = OptionalInt.of(distanceFromVersion);
+                firstSeq = rcNumber;
+                secondSeq = distanceFromVersion;
             }
             case RELEASE, NON_ORDERABLE -> {}
         }

--- a/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/OrderableSlsVersion.java
@@ -21,6 +21,7 @@ import static com.palantir.logsafe.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.palantir.logsafe.UnsafeArg;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 /**
@@ -37,6 +38,23 @@ public abstract class OrderableSlsVersion extends SlsVersion implements Comparab
         SlsVersionType.RELEASE_CANDIDATE_SNAPSHOT,
         SlsVersionType.RELEASE_SNAPSHOT
     };
+
+    @Nullable
+    final Integer rcNumber() {
+        return switch (getType()) {
+            case RELEASE_CANDIDATE, RELEASE_CANDIDATE_SNAPSHOT -> getFirstSequenceVersionNumber();
+            case RELEASE, RELEASE_SNAPSHOT, NON_ORDERABLE -> null;
+        };
+    }
+
+    @Nullable
+    final Integer snapshotNumber() {
+        return switch (getType()) {
+            case RELEASE_SNAPSHOT -> getFirstSequenceVersionNumber();
+            case RELEASE_CANDIDATE_SNAPSHOT -> getSecondSequenceVersionNumber();
+            case RELEASE, RELEASE_CANDIDATE, NON_ORDERABLE -> null;
+        };
+    }
 
     @JsonCreator
     public static OrderableSlsVersion valueOf(String value) {

--- a/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersion.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersion.java
@@ -23,8 +23,10 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.Serializable;
 import java.util.Optional;
 import java.util.OptionalInt;
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
+@SuppressWarnings("DesignForExtension")
 public abstract class SlsVersion implements Serializable {
 
     @JsonCreator
@@ -62,9 +64,21 @@ public abstract class SlsVersion implements Serializable {
 
     public abstract int getPatchVersionNumber();
 
-    public abstract OptionalInt firstSequenceVersionNumber();
+    @Nullable
+    abstract Integer getFirstSequenceVersionNumber();
 
-    public abstract OptionalInt secondSequenceVersionNumber();
+    public OptionalInt firstSequenceVersionNumber() {
+        Integer firstSeq = getFirstSequenceVersionNumber();
+        return firstSeq == null ? OptionalInt.empty() : OptionalInt.of(firstSeq);
+    }
+
+    @Nullable
+    abstract Integer getSecondSequenceVersionNumber();
+
+    public OptionalInt secondSequenceVersionNumber() {
+        Integer secondSeq = getSecondSequenceVersionNumber();
+        return secondSeq == null ? OptionalInt.empty() : OptionalInt.of(secondSeq);
+    }
 
     public abstract SlsVersionType getType();
 }

--- a/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersionType.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/SlsVersionType.java
@@ -23,9 +23,9 @@ import java.util.regex.Pattern;
  * {@link SlsVersion} objects.
  */
 public enum SlsVersionType {
-    RELEASE_SNAPSHOT(RegexParser.of("^([0-9]+)\\.([0-9]+)\\.([0-9]+)-([0-9]+)-g[a-f0-9]+$"), 4),
-    RELEASE(ReleaseVersionParser.INSTANCE, 3),
-    RELEASE_CANDIDATE_SNAPSHOT(RegexParser.of("^([0-9]+)\\.([0-9]+)\\.([0-9]+)-rc([0-9]+)-([0-9]+)-g[a-f0-9]+$"), 2),
+    RELEASE_SNAPSHOT(RegexParser.of("^([0-9]+)\\.([0-9]+)\\.([0-9]+)-([0-9]+)-g[a-f0-9]+$"), 3),
+    RELEASE(ReleaseVersionParser.INSTANCE, 2),
+    RELEASE_CANDIDATE_SNAPSHOT(RegexParser.of("^([0-9]+)\\.([0-9]+)\\.([0-9]+)-rc([0-9]+)-([0-9]+)-g[a-f0-9]+$"), 1),
     RELEASE_CANDIDATE(RegexParser.of("^([0-9]+)\\.([0-9]+)\\.([0-9]+)-rc([0-9]+)$"), 1),
     NON_ORDERABLE(RegexParser.of("^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-[a-z0-9-]+)?(\\.dirty)?$"), 0);
 

--- a/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
@@ -44,26 +44,25 @@ public enum VersionComparator implements Comparator<OrderableSlsVersion> {
             return result;
         }
 
+        // If release candidate version is not present, treat it the maximum value.
+        // All release and release snapshots versions are newer than any release candidate
+        //   or release candidate snapshot version.
+        Integer maybeRc1 = version1.rcNumber();
+        Integer maybeRc2 = version2.rcNumber();
         result = Integer.compare(
-                version1.getType().getPriority(), version2.getType().getPriority());
+                maybeRc1 == null ? Integer.MAX_VALUE : maybeRc1, maybeRc2 == null ? Integer.MAX_VALUE : maybeRc2);
         if (result != 0) {
             return result;
         }
 
-        Integer maybeFirstSequence1 = version1.getFirstSequenceVersionNumber();
-        Integer maybeFirstSequence2 = version2.getFirstSequenceVersionNumber();
+        // If snapshot version is not present, treat it as the minimum value.
+        // All release snapshots and release candidate snapshots versions are newer than
+        //   their corresponding release and release candidate versions, respectively.
+        Integer maybeSnapshot1 = version1.snapshotNumber();
+        Integer maybeSnapshot2 = version2.snapshotNumber();
         result = Integer.compare(
-                maybeFirstSequence1 == null ? 0 : maybeFirstSequence1,
-                maybeFirstSequence2 == null ? 0 : maybeFirstSequence2);
-        if (result != 0) {
-            return result;
-        }
-
-        Integer maybeSecondSequence1 = version1.getSecondSequenceVersionNumber();
-        Integer maybeSecondSequence2 = version2.getSecondSequenceVersionNumber();
-        result = Integer.compare(
-                maybeSecondSequence1 == null ? 0 : maybeSecondSequence1,
-                maybeSecondSequence2 == null ? 0 : maybeSecondSequence2);
+                maybeSnapshot1 == null ? Integer.MIN_VALUE : maybeSnapshot1,
+                maybeSnapshot2 == null ? Integer.MIN_VALUE : maybeSnapshot2);
         if (result != 0) {
             return result;
         }

--- a/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
@@ -23,8 +23,9 @@ public enum VersionComparator implements Comparator<OrderableSlsVersion> {
     INSTANCE;
 
     @Override
+    @SuppressWarnings("ImmutablesReferenceEquality")
     public int compare(OrderableSlsVersion version1, OrderableSlsVersion version2) {
-        if (version1.getValue().equals(version2.getValue())) {
+        if (version1 == version2) {
             return 0;
         }
 

--- a/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
@@ -16,95 +16,53 @@
 
 package com.palantir.sls.versions;
 
-import static com.palantir.logsafe.Preconditions.checkArgument;
-
-import com.palantir.logsafe.SafeArg;
 import java.util.Comparator;
-import java.util.OptionalInt;
 
 /** Compares {@link OrderableSlsVersion}s by "newness", i.e., "1.4.0" is greater/newer/later than "1.2.1", etc.. */
 public enum VersionComparator implements Comparator<OrderableSlsVersion> {
     INSTANCE;
 
     @Override
-    public int compare(OrderableSlsVersion left, OrderableSlsVersion right) {
-        if (left.getValue().equals(right.getValue())) {
+    public int compare(OrderableSlsVersion version1, OrderableSlsVersion version2) {
+        if (version1.getValue().equals(version2.getValue())) {
             return 0;
         }
 
-        int mainVersionComparison = compareMainVersion(left, right);
-        if (mainVersionComparison != 0) {
-            return mainVersionComparison;
+        int result = Integer.compare(version1.getMajorVersionNumber(), version2.getMajorVersionNumber());
+        if (result != 0) {
+            return result;
         }
 
-        if ((left.getType() == SlsVersionType.RELEASE) || (right.getType() == SlsVersionType.RELEASE)) {
-            // Releases always compare correctly just by type now we know base version matches.
-            return Integer.compare(left.getType().getPriority(), right.getType().getPriority());
+        result = Integer.compare(version1.getMinorVersionNumber(), version2.getMinorVersionNumber());
+        if (result != 0) {
+            return result;
         }
 
-        if ((left.getType() == SlsVersionType.RELEASE_SNAPSHOT)
-                && (right.getType() == SlsVersionType.RELEASE_SNAPSHOT)) {
-            // If both are snapshots, compare snapshot number.
-            return compareFirstSequenceVersions(left, right);
+        result = Integer.compare(version1.getPatchVersionNumber(), version2.getPatchVersionNumber());
+        if (result != 0) {
+            return result;
         }
 
-        if (left.getType() == SlsVersionType.RELEASE_SNAPSHOT) {
-            // Snapshot is larger.
-            return 1;
+        result = Integer.compare(
+                version1.getType().getPriority(), version2.getType().getPriority());
+        if (result != 0) {
+            return result;
         }
 
-        if (right.getType() == SlsVersionType.RELEASE_SNAPSHOT) {
-            // Snapshot is larger.
-            return -1;
+        result = Integer.compare(
+                version1.firstSequenceVersionNumber().orElse(0),
+                version2.firstSequenceVersionNumber().orElse(0));
+        if (result != 0) {
+            return result;
         }
 
-        return compareSuffix(left, right);
-    }
-
-    private int compareMainVersion(OrderableSlsVersion left, OrderableSlsVersion right) {
-        if (left.getMajorVersionNumber() != right.getMajorVersionNumber()) {
-            return left.getMajorVersionNumber() > right.getMajorVersionNumber() ? 1 : -1;
-        }
-
-        if (left.getMinorVersionNumber() != right.getMinorVersionNumber()) {
-            return left.getMinorVersionNumber() > right.getMinorVersionNumber() ? 1 : -1;
-        }
-
-        if (left.getPatchVersionNumber() != right.getPatchVersionNumber()) {
-            return left.getPatchVersionNumber() > right.getPatchVersionNumber() ? 1 : -1;
+        result = Integer.compare(
+                version1.secondSequenceVersionNumber().orElse(0),
+                version2.secondSequenceVersionNumber().orElse(0));
+        if (result != 0) {
+            return result;
         }
 
         return 0;
-    }
-
-    private int compareSuffix(OrderableSlsVersion left, OrderableSlsVersion right) {
-        // We know by this point that both are RCs or RC-snapshots.
-        // Compare RC number first.
-        int rcCompare = compareFirstSequenceVersions(left, right);
-        if (rcCompare != 0) {
-            return rcCompare;
-        }
-
-        // RC number is the same, compare snapshot versions.
-        // Substitute -1 if not present because snapshots are greater than non-snapshots.
-        OptionalInt leftInt = left.secondSequenceVersionNumber();
-        OptionalInt rightInt = right.secondSequenceVersionNumber();
-        return Integer.compare(leftInt.orElse(-1), rightInt.orElse(-1));
-    }
-
-    private int compareFirstSequenceVersions(OrderableSlsVersion left, OrderableSlsVersion right) {
-        OptionalInt leftInt = left.firstSequenceVersionNumber();
-        OptionalInt rightInt = right.firstSequenceVersionNumber();
-
-        checkArgument(
-                leftInt.isPresent(),
-                "Expected to find a first sequence number for version",
-                SafeArg.of("version", left.getValue()));
-        checkArgument(
-                rightInt.isPresent(),
-                "Expected to find a first sequence number for version",
-                SafeArg.of("version", right.getValue()));
-
-        return Integer.compare(leftInt.getAsInt(), rightInt.getAsInt());
     }
 }

--- a/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
+++ b/sls-versions/src/main/java/com/palantir/sls/versions/VersionComparator.java
@@ -50,16 +50,20 @@ public enum VersionComparator implements Comparator<OrderableSlsVersion> {
             return result;
         }
 
+        Integer maybeFirstSequence1 = version1.getFirstSequenceVersionNumber();
+        Integer maybeFirstSequence2 = version2.getFirstSequenceVersionNumber();
         result = Integer.compare(
-                version1.firstSequenceVersionNumber().orElse(0),
-                version2.firstSequenceVersionNumber().orElse(0));
+                maybeFirstSequence1 == null ? 0 : maybeFirstSequence1,
+                maybeFirstSequence2 == null ? 0 : maybeFirstSequence2);
         if (result != 0) {
             return result;
         }
 
+        Integer maybeSecondSequence1 = version1.getSecondSequenceVersionNumber();
+        Integer maybeSecondSequence2 = version2.getSecondSequenceVersionNumber();
         result = Integer.compare(
-                version1.secondSequenceVersionNumber().orElse(0),
-                version2.secondSequenceVersionNumber().orElse(0));
+                maybeSecondSequence1 == null ? 0 : maybeSecondSequence1,
+                maybeSecondSequence2 == null ? 0 : maybeSecondSequence2);
         if (result != 0) {
             return result;
         }

--- a/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/OrderableSlsVersionTests.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -281,9 +280,8 @@ public class OrderableSlsVersionTests {
                 .minorVersionNumber(minor)
                 .patchVersionNumber(patch)
                 .type(type)
-                .firstSequenceVersionNumber(firstSequence == null ? OptionalInt.empty() : OptionalInt.of(firstSequence))
-                .secondSequenceVersionNumber(
-                        secondSequence == null ? OptionalInt.empty() : OptionalInt.of(secondSequence))
+                .firstSequenceVersionNumber(firstSequence)
+                .secondSequenceVersionNumber(secondSequence)
                 .build();
     }
 }


### PR DESCRIPTION
This PR leverages https://github.com/palantir/sls-version-java/pull/1190 to compare the performance impact of the various different changes and options presented in https://github.com/palantir/sls-version-java/pull/1183 and https://github.com/palantir/sls-version-java/pull/1179

There are five different changes that are being tested:
- [Develop](https://github.com/palantir/sls-version-java/commit/92bbacb9e9a9487742d1af4593fea8876c9dcd09)
  - One thing of note is that we're allocating memory (24B / comparison) when comparing `RC`/`RC_SNAPSHOT`, due to accessing the `firstSequenceVersionNumber` and `secondSequenceVersionNumber` methods (Immutables generate the internal fields as nullable `Integer`s and creates a new `OptionalInt` on access)
- [Updating the `RC_SNAPSHOT` priority and leveraging that to streamline the version comparisons](https://github.com/palantir/sls-version-java/commit/380ab3405b62eba496f52c58ce4896b4c0e3e977)
  - This has roughly the same performance, except when comparing `RC`/`RC_SNAPSHOT` versions, where it's more performant by ~10-20% (most likely due to the convoluted nature of the existing logic)
  - This has no impact on memory allocation
- [Using identity comparison as the short-circuit for identical versions (rather than comparing strings)](https://github.com/palantir/sls-version-java/commit/b81d0738dd6159168a70dd265885f5bf0bb3d9ba)
  - This roughly doubles the time needed to compare identical versions which don't use the same `ImmutableOrderableSlsVersion` object (going from ~1ns/op to ~2-2.5ns/op)
  - This saves ~30% on all other comparisons (going from ~3ns/op to ~2ns/op for the majority of cases)
- [Avoiding extra allocations when accessing optional/nullable fields in immutable versions from within the comparisons](https://github.com/palantir/sls-version-java/commit/7adee68fdef31fd3e4fa7ac820aa5b7eec7c0596)
  - This saves an extra ~20% speed on the `RC`/`RC_SNAPSHOT` cases, bringing them in line with the rest of the cases
  - This also avoids memory allocation entirely, in any of the comparisons
- [Add `rcNumber` and `snapshotNumber` convenience methods, that switch on the type, and removing priority comparison from the logic](https://github.com/palantir/sls-version-java/commit/cd1231b47243131e8624b45fb82734a2a37ca74d)
  - Despite the nice to have methods, the switch these contain incur an inherent cost of ~30-50% perf on the comparisons
  - If we were able to save these as fields, we would be able to get back to the same performance.
    - However, this would allocate extra memory (because we're sensible on memory allocation upon parsing).
    - We also can't save memory by removing the other `XSequenceVersionNumber` fields as was originally done in https://github.com/palantir/sls-version-java/pull/1183, because this would break compatibility with regards to Java serialization (since `SlsVersion` is `Serializable`), and I haven't found a way to circumvent that (which would probably be unnecessarily complex)
 
Of note as well, speed of the comparisons might not matter as much, considering how fast they are. It's likely that we could incur any of the costs described here without any problem anywhere.

Below you'll find the detailed benchmark results for each of these:

[Develop](https://github.com/palantir/sls-version-java/commit/92bbacb9e9a9487742d1af4593fea8876c9dcd09)

```
Benchmark                                                  (version1)   (version2)  Mode  Cnt      Score     Error   Units
SlsVersionComparisonBenchmark.compare                         RELEASE      RELEASE  avgt    3      1.099 ±   1.359   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE      RELEASE  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE      RELEASE  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE      RELEASE  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                         RELEASE     SNAPSHOT  avgt    3      3.278 ±   0.036   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE     SNAPSHOT  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE     SNAPSHOT  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE     SNAPSHOT  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                         RELEASE           RC  avgt    3      2.931 ±   0.035   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE           RC  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE           RC  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE           RC  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                         RELEASE  RC_SNAPSHOT  avgt    3      2.970 ±   0.810   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE  RC_SNAPSHOT  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE  RC_SNAPSHOT  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE  RC_SNAPSHOT  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT      RELEASE  avgt    3      3.062 ±   1.608   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT      RELEASE  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT      RELEASE  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT      RELEASE  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT     SNAPSHOT  avgt    3      1.131 ±   0.002   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT     SNAPSHOT  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT     SNAPSHOT  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT     SNAPSHOT  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT           RC  avgt    3      2.996 ±   1.225   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT           RC  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT           RC  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT           RC  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT  RC_SNAPSHOT  avgt    3      3.039 ±   0.455   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT  RC_SNAPSHOT  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT  RC_SNAPSHOT  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT  RC_SNAPSHOT  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                              RC      RELEASE  avgt    3      2.988 ±   0.283   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC      RELEASE  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC      RELEASE  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC      RELEASE  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                              RC     SNAPSHOT  avgt    3      2.755 ±   0.565   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC     SNAPSHOT  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC     SNAPSHOT  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC     SNAPSHOT  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                              RC           RC  avgt    3      1.044 ±   0.185   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC           RC  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC           RC  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC           RC  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                              RC  RC_SNAPSHOT  avgt    3      7.564 ±   0.572   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC  RC_SNAPSHOT  avgt    3  12103.480 ± 912.076  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC  RC_SNAPSHOT  avgt    3     24.000 ±   0.001    B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC  RC_SNAPSHOT  avgt    3    178.000            counts
SlsVersionComparisonBenchmark.compare:gc.time                      RC  RC_SNAPSHOT  avgt    3     92.000                ms
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT      RELEASE  avgt    3      3.014 ±   0.109   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT      RELEASE  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT      RELEASE  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT      RELEASE  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT     SNAPSHOT  avgt    3      3.085 ±   0.459   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT     SNAPSHOT  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT     SNAPSHOT  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT     SNAPSHOT  avgt    3        ≈ 0            counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT           RC  avgt    3      7.042 ±   0.283   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT           RC  avgt    3  12999.078 ± 520.953  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT           RC  avgt    3     24.000 ±   0.001    B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT           RC  avgt    3    191.000            counts
SlsVersionComparisonBenchmark.compare:gc.time             RC_SNAPSHOT           RC  avgt    3     99.000                ms
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT  RC_SNAPSHOT  avgt    3      1.098 ±   0.046   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT  RC_SNAPSHOT  avgt    3      0.003 ±   0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT  RC_SNAPSHOT  avgt    3     ≈ 10⁻⁶              B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT  RC_SNAPSHOT  avgt    3        ≈ 0            counts
```

[Updating the `RC_SNAPSHOT` priority and leveraging that to streamline the version comparisons](https://github.com/palantir/sls-version-java/commit/380ab3405b62eba496f52c58ce4896b4c0e3e977)
```
Benchmark                                                  (version1)   (version2)  Mode  Cnt      Score      Error   Units
SlsVersionComparisonBenchmark.compare                         RELEASE      RELEASE  avgt    3      1.121 ±    0.085   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE      RELEASE  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE      RELEASE  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE      RELEASE  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                         RELEASE     SNAPSHOT  avgt    3      2.990 ±    0.342   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE     SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE     SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE     SNAPSHOT  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                         RELEASE           RC  avgt    3      3.103 ±    0.693   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE           RC  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE           RC  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE           RC  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                         RELEASE  RC_SNAPSHOT  avgt    3      3.172 ±    0.502   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE  RC_SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE  RC_SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE  RC_SNAPSHOT  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT      RELEASE  avgt    3      3.140 ±    0.646   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT      RELEASE  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT      RELEASE  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT      RELEASE  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT     SNAPSHOT  avgt    3      1.100 ±    0.344   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT     SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT     SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT     SNAPSHOT  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT           RC  avgt    3      3.126 ±    0.243   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT           RC  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT           RC  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT           RC  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT  RC_SNAPSHOT  avgt    3      3.177 ±    0.124   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT  RC_SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT  RC_SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT  RC_SNAPSHOT  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                              RC      RELEASE  avgt    3      2.932 ±    0.065   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC      RELEASE  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC      RELEASE  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC      RELEASE  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                              RC     SNAPSHOT  avgt    3      3.060 ±    0.035   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC     SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC     SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC     SNAPSHOT  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                              RC           RC  avgt    3      1.172 ±    0.823   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC           RC  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC           RC  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC           RC  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                              RC  RC_SNAPSHOT  avgt    3      5.834 ±    0.901   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC  RC_SNAPSHOT  avgt    3  15692.566 ± 2416.603  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC  RC_SNAPSHOT  avgt    3     24.000 ±    0.001    B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC  RC_SNAPSHOT  avgt    3    231.000             counts
SlsVersionComparisonBenchmark.compare:gc.time                      RC  RC_SNAPSHOT  avgt    3    121.000                 ms
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT      RELEASE  avgt    3      2.975 ±    0.068   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT      RELEASE  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT      RELEASE  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT      RELEASE  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT     SNAPSHOT  avgt    3      2.991 ±    0.177   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT     SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT     SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT     SNAPSHOT  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT           RC  avgt    3      5.848 ±    0.235   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT           RC  avgt    3  15654.987 ±  626.743  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT           RC  avgt    3     24.000 ±    0.001    B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT           RC  avgt    3    230.000             counts
SlsVersionComparisonBenchmark.compare:gc.time             RC_SNAPSHOT           RC  avgt    3    117.000                 ms
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT  RC_SNAPSHOT  avgt    3      1.087 ±    0.597   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT  RC_SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT  RC_SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT  RC_SNAPSHOT  avgt    3        ≈ 0             counts
```

[Using identity comparison as the short-circuit for identical versions (rather than comparing strings)](https://github.com/palantir/sls-version-java/commit/b81d0738dd6159168a70dd265885f5bf0bb3d9ba)
```
Benchmark                                                  (version1)   (version2)  Mode  Cnt      Score      Error   Units
SlsVersionComparisonBenchmark.compare                         RELEASE      RELEASE  avgt    3      2.500 ±    0.420   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE      RELEASE  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE      RELEASE  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE      RELEASE  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                         RELEASE     SNAPSHOT  avgt    3      1.973 ±    0.242   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE     SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE     SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE     SNAPSHOT  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                         RELEASE           RC  avgt    3      2.079 ±    0.467   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE           RC  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE           RC  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE           RC  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                         RELEASE  RC_SNAPSHOT  avgt    3      2.131 ±    0.090   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE  RC_SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE  RC_SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE  RC_SNAPSHOT  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT      RELEASE  avgt    3      2.072 ±    0.253   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT      RELEASE  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT      RELEASE  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT      RELEASE  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT     SNAPSHOT  avgt    3      3.321 ±    0.085   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT     SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT     SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT     SNAPSHOT  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT           RC  avgt    3      2.052 ±    0.092   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT           RC  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT           RC  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT           RC  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT  RC_SNAPSHOT  avgt    3      2.145 ±    0.280   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT  RC_SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT  RC_SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT  RC_SNAPSHOT  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                              RC      RELEASE  avgt    3      1.918 ±    0.417   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC      RELEASE  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC      RELEASE  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC      RELEASE  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                              RC     SNAPSHOT  avgt    3      1.989 ±    0.124   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC     SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC     SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC     SNAPSHOT  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                              RC           RC  avgt    3      3.161 ±    0.224   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC           RC  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC           RC  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC           RC  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                              RC  RC_SNAPSHOT  avgt    3      4.541 ±    1.673   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC  RC_SNAPSHOT  avgt    3  20164.015 ± 7355.897  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC  RC_SNAPSHOT  avgt    3     24.000 ±    0.001    B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC  RC_SNAPSHOT  avgt    3    238.000             counts
SlsVersionComparisonBenchmark.compare:gc.time                      RC  RC_SNAPSHOT  avgt    3    126.000                 ms
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT      RELEASE  avgt    3      1.925 ±    0.367   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT      RELEASE  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT      RELEASE  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT      RELEASE  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT     SNAPSHOT  avgt    3      1.924 ±    0.307   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT     SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT     SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT     SNAPSHOT  avgt    3        ≈ 0             counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT           RC  avgt    3      4.566 ±    1.142   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT           RC  avgt    3  20052.310 ± 4974.887  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT           RC  avgt    3     24.000 ±    0.001    B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT           RC  avgt    3    236.000             counts
SlsVersionComparisonBenchmark.compare:gc.time             RC_SNAPSHOT           RC  avgt    3    126.000                 ms
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT  RC_SNAPSHOT  avgt    3      3.351 ±    0.612   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT  RC_SNAPSHOT  avgt    3      0.003 ±    0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT  RC_SNAPSHOT  avgt    3     ≈ 10⁻⁶               B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT  RC_SNAPSHOT  avgt    3        ≈ 0             counts
```

[Avoiding extra allocations when accessing optional/nullable fields in immutable versions from within the comparisons](https://github.com/palantir/sls-version-java/commit/7adee68fdef31fd3e4fa7ac820aa5b7eec7c0596)
```
Benchmark                                                  (version1)   (version2)  Mode  Cnt   Score    Error   Units
SlsVersionComparisonBenchmark.compare                         RELEASE      RELEASE  avgt    3   2.890 ±  3.450   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE      RELEASE  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE      RELEASE  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE      RELEASE  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                         RELEASE     SNAPSHOT  avgt    3   2.131 ±  1.226   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE     SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE     SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE     SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                         RELEASE           RC  avgt    3   2.261 ±  0.700   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE           RC  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE           RC  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE           RC  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                         RELEASE  RC_SNAPSHOT  avgt    3   2.150 ±  0.374   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE  RC_SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE  RC_SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE  RC_SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT      RELEASE  avgt    3   2.093 ±  0.339   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT      RELEASE  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT      RELEASE  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT      RELEASE  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT     SNAPSHOT  avgt    3   3.044 ±  0.639   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT     SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT     SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT     SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT           RC  avgt    3   2.176 ±  0.384   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT           RC  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT           RC  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT           RC  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT  RC_SNAPSHOT  avgt    3   2.115 ±  0.470   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT  RC_SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT  RC_SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT  RC_SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                              RC      RELEASE  avgt    3   2.033 ±  0.469   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC      RELEASE  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC      RELEASE  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC      RELEASE  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                              RC     SNAPSHOT  avgt    3   2.012 ±  0.729   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC     SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC     SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC     SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                              RC           RC  avgt    3   2.974 ±  0.102   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC           RC  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC           RC  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC           RC  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                              RC  RC_SNAPSHOT  avgt    3   3.283 ±  1.716   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC  RC_SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC  RC_SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC  RC_SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT      RELEASE  avgt    3   2.033 ±  0.608   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT      RELEASE  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT      RELEASE  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT      RELEASE  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT     SNAPSHOT  avgt    3   1.931 ±  0.038   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT     SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT     SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT     SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT           RC  avgt    3   3.231 ±  1.509   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT           RC  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT           RC  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT           RC  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT  RC_SNAPSHOT  avgt    3   3.269 ±  0.544   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT  RC_SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT  RC_SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT  RC_SNAPSHOT  avgt    3     ≈ 0           counts
```

[Add `rcNumber` and `snapshotNumber` convenience methods, that switch on the type, and removing priority comparison from the logic](https://github.com/palantir/sls-version-java/commit/cd1231b47243131e8624b45fb82734a2a37ca74d)
```
Benchmark                                                  (version1)   (version2)  Mode  Cnt   Score    Error   Units
SlsVersionComparisonBenchmark.compare                         RELEASE      RELEASE  avgt    3   2.507 ±  1.990   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE      RELEASE  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE      RELEASE  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE      RELEASE  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                         RELEASE     SNAPSHOT  avgt    3   2.907 ±  0.645   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE     SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE     SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE     SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                         RELEASE           RC  avgt    3   2.798 ±  0.487   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE           RC  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE           RC  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE           RC  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                         RELEASE  RC_SNAPSHOT  avgt    3   2.818 ±  1.102   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate           RELEASE  RC_SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm      RELEASE  RC_SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                RELEASE  RC_SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT      RELEASE  avgt    3   2.852 ±  0.012   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT      RELEASE  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT      RELEASE  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT      RELEASE  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT     SNAPSHOT  avgt    3   2.885 ±  0.057   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT     SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT     SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT     SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT           RC  avgt    3   2.755 ±  0.362   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT           RC  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT           RC  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT           RC  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                        SNAPSHOT  RC_SNAPSHOT  avgt    3   2.897 ±  0.887   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate          SNAPSHOT  RC_SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm     SNAPSHOT  RC_SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count               SNAPSHOT  RC_SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                              RC      RELEASE  avgt    3   2.646 ±  0.376   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC      RELEASE  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC      RELEASE  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC      RELEASE  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                              RC     SNAPSHOT  avgt    3   2.645 ±  0.011   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC     SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC     SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC     SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                              RC           RC  avgt    3   2.837 ±  0.050   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC           RC  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC           RC  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC           RC  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                              RC  RC_SNAPSHOT  avgt    3   3.509 ±  0.624   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate                RC  RC_SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm           RC  RC_SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count                     RC  RC_SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT      RELEASE  avgt    3   2.639 ±  0.031   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT      RELEASE  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT      RELEASE  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT      RELEASE  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT     SNAPSHOT  avgt    3   2.798 ±  0.011   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT     SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT     SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT     SNAPSHOT  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT           RC  avgt    3   3.350 ±  0.010   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT           RC  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT           RC  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT           RC  avgt    3     ≈ 0           counts
SlsVersionComparisonBenchmark.compare                     RC_SNAPSHOT  RC_SNAPSHOT  avgt    3   3.662 ±  0.029   ns/op
SlsVersionComparisonBenchmark.compare:gc.alloc.rate       RC_SNAPSHOT  RC_SNAPSHOT  avgt    3   0.003 ±  0.001  MB/sec
SlsVersionComparisonBenchmark.compare:gc.alloc.rate.norm  RC_SNAPSHOT  RC_SNAPSHOT  avgt    3  ≈ 10⁻⁶             B/op
SlsVersionComparisonBenchmark.compare:gc.count            RC_SNAPSHOT  RC_SNAPSHOT  avgt    3     ≈ 0           counts
```