### PR TITLE
Use quicktheories for property-based-testing

### DIFF
--- a/sls-versions/build.gradle
+++ b/sls-versions/build.gradle
@@ -16,19 +16,12 @@ dependencies {
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'com.google.guava:guava'
-    testImplementation 'net.jqwik:jqwik-api'
-    testRuntimeOnly 'net.jqwik:jqwik'
+    testImplementation 'org.quicktheories:quicktheories'
 
     jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
     jmh 'org.openjdk.jmh:jmh-core'
     jmh project(':sls-versions')
     jmh 'org.apache.logging.log4j:log4j-slf4j-impl'
-}
-
-tasks.withType(Test) {
-    useJUnitPlatform {
-        includeEngines 'jqwik', 'junit-jupiter'
-    }
 }
 
 jmh {

--- a/sls-versions/src/test/java/com/palantir/sls/versions/SlsVersionMatcherParserTest.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/SlsVersionMatcherParserTest.java
@@ -17,21 +17,20 @@
 package com.palantir.sls.versions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.Generate.constant;
+import static org.quicktheories.generators.Generate.oneOf;
+import static org.quicktheories.generators.Generate.pick;
+import static org.quicktheories.generators.SourceDSL.integers;
+import static org.quicktheories.generators.SourceDSL.lists;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
-import net.jqwik.api.constraints.Chars;
-import net.jqwik.api.constraints.NumericChars;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.quicktheories.core.Gen;
 
 /**
- * This test uses the <a href="https://jqwik.net/">jqwik library</a>
+ * This test uses the <a href="https://github.com/quicktheories/QuickTheories">QuickTheories library</a>
  * to generate a whole bunch of random test cases, and validate that the {@link SlsVersionMatcherParser} behaves
  * identically to the reference {@link RegexSlsVersionMatcherParser}.
  *
@@ -41,35 +40,41 @@ import net.jqwik.api.constraints.NumericChars;
  */
 public final class SlsVersionMatcherParserTest {
 
-    @Property(seed = "3226259347315412165", tries = 2000)
-    public void valid_parsing(
-            @ForAll("validComponent") String major,
-            @ForAll("validComponent") String minor,
-            @ForAll("validComponent") String patch) {
-        String string = major + '.' + minor + '.' + patch;
-        assertThat(SlsVersionMatcherParser.safeValueOf(string))
-                .describedAs(string)
-                .isEqualTo(RegexSlsVersionMatcherParser.safeValueOf(string));
+    private static Gen<String> validComponent() {
+        return oneOf(constant("x"), integers().allPositive().map(i -> Integer.toString(i)));
     }
 
-    @Provide
-    public Arbitrary<String> validComponent() {
-        Arbitrary<String> justX = Arbitraries.just("x");
-        Arbitrary<String> integerArbitrary =
-                Arbitraries.integers().greaterOrEqual(0).map(a -> Integer.toString(a));
-        return Arbitraries.oneOf(justX, integerArbitrary);
+    @Test
+    public void valid_parsing() {
+        qt().withExamples(2000)
+                .forAll(validComponent(), validComponent(), validComponent())
+                .checkAssert((major, minor, patch) -> {
+                    String string = major + "." + minor + "." + patch;
+                    assertThat(SlsVersionMatcherParser.safeValueOf(string))
+                            .describedAs(string)
+                            .isEqualTo(RegexSlsVersionMatcherParser.safeValueOf(string));
+                });
     }
 
-    @Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER})
-    @Retention(RetentionPolicy.RUNTIME)
-    @NumericChars
-    @Chars({'x', '.'})
-    public @interface Nonsense {}
+    private static final List<Character> NONSENSE_CHARS =
+            Arrays.asList('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'x', '.');
 
-    @Property(seed = "3226259347315412165", tries = 2000)
-    public void nonsense_parsing(@ForAll @Nonsense String nonsense) {
-        assertThat(SlsVersionMatcherParser.safeValueOf(nonsense))
-                .describedAs(nonsense)
-                .isEqualTo(RegexSlsVersionMatcherParser.safeValueOf(nonsense));
+    @Test
+    public void nonsense_parsing() {
+        Gen<String> nonsense = lists().of(pick(NONSENSE_CHARS))
+                .ofSizeBetween(0, 10)
+                .map(chars -> {
+                    StringBuilder sb = new StringBuilder(chars.size());
+                    for (char ch : chars) {
+                        sb.append(ch);
+                    }
+                    return sb.toString();
+                });
+
+        qt().withExamples(2000).forAll(nonsense).checkAssert(str -> {
+            assertThat(SlsVersionMatcherParser.safeValueOf(str))
+                    .describedAs(str)
+                    .isEqualTo(RegexSlsVersionMatcherParser.safeValueOf(str));
+        });
     }
 }

--- a/sls-versions/src/test/java/com/palantir/sls/versions/SlsVersionMatcherParserTest.java
+++ b/sls-versions/src/test/java/com/palantir/sls/versions/SlsVersionMatcherParserTest.java
@@ -19,7 +19,7 @@ package com.palantir.sls.versions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.Generate.constant;
-import static org.quicktheories.generators.Generate.oneOf;
+import static org.quicktheories.generators.Generate.frequency;
 import static org.quicktheories.generators.Generate.pick;
 import static org.quicktheories.generators.SourceDSL.integers;
 import static org.quicktheories.generators.SourceDSL.lists;
@@ -27,6 +27,7 @@ import static org.quicktheories.generators.SourceDSL.lists;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.quicktheories.api.Pair;
 import org.quicktheories.core.Gen;
 
 /**
@@ -41,7 +42,8 @@ import org.quicktheories.core.Gen;
 public final class SlsVersionMatcherParserTest {
 
     private static Gen<String> validComponent() {
-        return oneOf(constant("x"), integers().allPositive().map(i -> Integer.toString(i)));
+        return frequency(
+                Pair.of(99, integers().allPositive().map(i -> Integer.toString(i))), Pair.of(1, constant("x")));
     }
 
     @Test
@@ -65,9 +67,7 @@ public final class SlsVersionMatcherParserTest {
                 .ofSizeBetween(0, 10)
                 .map(chars -> {
                     StringBuilder sb = new StringBuilder(chars.size());
-                    for (char ch : chars) {
-                        sb.append(ch);
-                    }
+                    chars.forEach(sb::append);
                     return sb.toString();
                 });
 

--- a/versions.lock
+++ b/versions.lock
@@ -42,12 +42,6 @@ com.google.j2objc:j2objc-annotations:3.1 (1 constraints: b809f1a0)
 
 net.bytebuddy:byte-buddy:1.18.3 (1 constraints: 530b55df)
 
-net.jqwik:jqwik:1.3.7 (1 constraints: 0d050036)
-
-net.jqwik:jqwik-api:1.3.7 (2 constraints: de117b11)
-
-net.jqwik:jqwik-engine:1.3.7 (1 constraints: 9e07f26c)
-
 net.sf.jopt-simple:jopt-simple:5.0.4 (1 constraints: be0ad6cc)
 
 org.apache.commons:commons-math3:3.6.1 (1 constraints: bf0adbcc)
@@ -58,7 +52,7 @@ org.apache.logging.log4j:log4j-core:2.25.3 (1 constraints: d8100adf)
 
 org.apache.logging.log4j:log4j-slf4j-impl:2.25.3 (1 constraints: 3e05453b)
 
-org.apiguardian:apiguardian-api:1.1.2 (9 constraints: 1981f01e)
+org.apiguardian:apiguardian-api:1.1.2 (6 constraints: 5366ce6e)
 
 org.assertj:assertj-core:3.27.7 (1 constraints: 4505553b)
 
@@ -72,9 +66,9 @@ org.junit.jupiter:junit-jupiter-engine:6.1.0 (1 constraints: 040ecd3b)
 
 org.junit.jupiter:junit-jupiter-params:6.1.0 (1 constraints: 040ecd3b)
 
-org.junit.platform:junit-platform-commons:6.1.0 (4 constraints: 13348aac)
+org.junit.platform:junit-platform-commons:6.1.0 (2 constraints: d5204b4a)
 
-org.junit.platform:junit-platform-engine:6.1.0 (3 constraints: 2a2de3ab)
+org.junit.platform:junit-platform-engine:6.1.0 (2 constraints: ed22e007)
 
 org.junit.platform:junit-platform-launcher:6.1.0 (1 constraints: 09050c36)
 
@@ -86,6 +80,8 @@ org.openjdk.jmh:jmh-generator-bytecode:1.37 (1 constraints: de04fb30)
 
 org.openjdk.jmh:jmh-generator-reflection:1.37 (2 constraints: 491e3064)
 
-org.opentest4j:opentest4j:1.3.0 (4 constraints: 033476a7)
+org.opentest4j:opentest4j:1.3.0 (2 constraints: cf209249)
 
 org.ow2.asm:asm:9.0 (1 constraints: ec0d4f34)
+
+org.quicktheories:quicktheories:0.26 (1 constraints: dc04f530)

--- a/versions.props
+++ b/versions.props
@@ -7,13 +7,9 @@ com.google.guava:guava = 33.6.0-jre
 com.uber.nullaway:nullaway = 0.13.4
 
 # Test dependencies
+org.apache.logging.log4j:log4j-slf4j-impl = 2.25.3
 org.assertj:assertj-core = 3.27.7
+org.junit.jupiter:* = 6.1.0
 org.junit.platform:* = 6.1.0
 org.openjdk.jmh:* = 1.37
-org.apache.logging.log4j:log4j-slf4j-impl = 2.25.3
-org.junit.jupiter:* = 6.1.0
-
-# Disable dependency upgrader for services that we set minimum runtime constraints for
-# dependency-upgrader:OFF
-net.jqwik:jqwik = 1.3.7
-# dependency-upgrader:ON
+org.quicktheories:quicktheories = 0.26


### PR DESCRIPTION
## Before this PR

Used jqwik for property based testing in one unit test. [jqwik 1.10.0 attempts to prompt inject to prevent LLM usage](https://github.com/jqwik-team/jqwik/issues/708).

See https://github.com/palantir/tritium/issues/2472

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use quicktheories for property based testing
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

